### PR TITLE
Fix issues in batch parsing and table quench

### DIFF
--- a/Schema.UnitTests/SqlHelpersTests.cs
+++ b/Schema.UnitTests/SqlHelpersTests.cs
@@ -160,4 +160,22 @@ GO";
         var batches = SqlHelpers.SplitIntoBatches(sql);
         Assert.That(batches, Has.Count.EqualTo(2));
     }
+
+    [Test]
+    public void FigureOutBatchParseIssue()
+    {
+        const string sql = @"
+create procedure dbo.TestProc (
+        @P_Year      int,                       /* year     - e.g. 2010 or 2011, etc. */
+        @P_Quarter   int,                       /* Quarter  - 1,2,3,4 */
+        @P_FilePath  varchar(500)  = 'D:\Temp\',/* path on the SQL Server machine -- MUST exist - e.g. 'C:\Temp\' */
+        @P_Clients   varchar(MAX)  = NULL,
+        @P_Transfer  bit = 1
+) as
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+GO
+";
+        var batches = SqlHelpers.SplitIntoBatches(sql);
+        Assert.That(batches, Has.Count.EqualTo(1));
+    }
 }

--- a/Schema/DataAccess/SqlHelpers.cs
+++ b/Schema/DataAccess/SqlHelpers.cs
@@ -11,13 +11,14 @@ public static class SqlHelpers
         var batches = new List<string>();
         var lines = (script + "\nGO") // make sure we end with a GO
             .Replace("\r\n", "\n").Replace("\r", "\n") // normalize line endings
-            .Split(new[] { '\n' }, StringSplitOptions.None);
+            .Split(['\n'], StringSplitOptions.None);
         var batch = new StringBuilder();
         var inMultiLine = false;
         var inString = false;
+        var inString2 = false;
         foreach (var line in lines)
         {
-            var cleanLine = CleanseLine(line, ref inString, ref inMultiLine);
+            var cleanLine = CleanseLine(line, ref inString, ref inString2, ref inMultiLine);
             if (cleanLine == "GO")
             {
                 var batchStr = batch.ToString();
@@ -32,12 +33,12 @@ public static class SqlHelpers
         }
 
         if (!string.IsNullOrWhiteSpace(batch.ToString()) && batch.Length > 0)
-            throw new Exception("Batch Parsing Failed");
+            throw new Exception("Batch Parsing Failed: " + (inString ? "Unterminated single quote string" : inString2 ? "Unterminated double quote string" : inMultiLine ? "Unterminated comment" : ""));
         return batches;
     }
 
     // Handle strings in comments and comments in strings while hunting for batch terminators
-    private static string CleanseLine(string line, ref bool inString, ref bool inMultiLine)
+    private static string CleanseLine(string line, ref bool inString, ref bool inString2, ref bool inMultiLine)
     {
         var cleanLine = line;
 
@@ -46,7 +47,17 @@ public static class SqlHelpers
             if (cleanLine.Contains("'"))
             {
                 inString = false;
-                return CleanseLine(cleanLine.Substring(cleanLine.IndexOf("'") + 1), ref inString, ref inMultiLine);
+                return CleanseLine(cleanLine.Substring(cleanLine.IndexOf("'", StringComparison.Ordinal) + 1), ref inString, ref inString2, ref inMultiLine);
+            }
+
+            cleanLine = "";
+        }
+        else if (inString2)
+        {
+            if (cleanLine.Contains("\""))
+            {
+                inString2 = false;
+                return CleanseLine(cleanLine.Substring(cleanLine.IndexOf("\"", StringComparison.Ordinal) + 1), ref inString, ref inString2, ref inMultiLine);
             }
 
             cleanLine = "";
@@ -56,30 +67,37 @@ public static class SqlHelpers
             if (cleanLine.Contains("*/"))
             {
                 inMultiLine = false;
-                return CleanseLine(cleanLine.Substring(cleanLine.IndexOf("*/") + 2), ref inString, ref inMultiLine);
+                return CleanseLine(cleanLine.Substring(cleanLine.IndexOf("*/", StringComparison.Ordinal) + 2), ref inString, ref inString2, ref inMultiLine);
             }
 
             cleanLine = "";
         }
         else
         {
-            var s = cleanLine.IndexOf("'");
-            var sc = cleanLine.IndexOf("--");
-            var mc = cleanLine.IndexOf("/*");
-            if (s > -1 && (mc > s || mc == -1) && (sc > s || sc == -1))
+            var s = cleanLine.IndexOf("'", StringComparison.Ordinal);
+            var s2 = cleanLine.IndexOf("\"", StringComparison.Ordinal);
+            var sc = cleanLine.IndexOf("--", StringComparison.Ordinal);
+            var mc = cleanLine.IndexOf("/*", StringComparison.Ordinal);
+            if (s > -1 && (s2 > s || s2 == -1) && (mc > s || mc == -1) && (sc > s || sc == -1))
             {
                 inString = true;
-                return CleanseLine(cleanLine.Substring(s + 1), ref inString, ref inMultiLine);
+                return CleanseLine(cleanLine.Substring(s + 1), ref inString, ref inString2, ref inMultiLine);
             }
 
-            if (mc > -1 && (mc > sc || sc == -1))
+            if (s2 > -1 && (mc > s2 || mc == -1) && (sc > s2 || sc == -1))
+            {
+                inString2 = true;
+                return CleanseLine(cleanLine.Substring(s2 + 1), ref inString, ref inString2, ref inMultiLine);
+            }
+
+            if (mc > -1 && (sc > mc || sc == -1))
             {
                 inMultiLine = true;
-                return CleanseLine(cleanLine.Substring(mc + 2), ref inString, ref inMultiLine);
+                return CleanseLine(cleanLine.Substring(mc + 2), ref inString, ref inString2, ref inMultiLine);
             }
 
             if (sc > -1)
-                return CleanseLine(cleanLine.Substring(0, sc), ref inString, ref inMultiLine);
+                return CleanseLine(cleanLine.Substring(0, sc), ref inString, ref inString2, ref inMultiLine);
         }
 
         return cleanLine.Trim('\t', ' ').ToUpper();


### PR DESCRIPTION
- Fixed issues in the batch parser
- Fixed an issue with the Quench db command ending up in the wrong DB on the connection when a script has "USE" in it
- Fixed an issue handling blank compression type in the table quench script
- Fixed an issue with lots of foreign key drops causing a STRING_AGG length error in the table quench script
- Fixed the table quench script to ignore new tables with no columns defined
- Handle the ROWVERSION synonym for TIMESTAMP in the table quench script
