### PR TITLE
DataTongs fixes and enhancements

### DIFF
--- a/DataTongs/appsettings.json
+++ b/DataTongs/appsettings.json
@@ -8,8 +8,10 @@
     "OutputPath": "",
     "Tables": {
     },
+    "TableFilters": {
+    },
     "ShouldCast": {
-        "MergeInsert": true,
-        "MergeUpdata": true
+        "MergeUpdate": true,
+        "MergeDelete": false
     }
 }


### PR DESCRIPTION
- Fix DataTongs config MergeUpdate key typo
- Remove the MergeInsert key from the DataTongs config (insert should always generate)
- Add MergeDelete key to the DataTongs config and generate the delete section of the merge statement
- Add support for filter expressions by table to DataTongs for the data selection and merge delete
- Refactored the code for readability