### PR TITLE
Turning off AOT to work around erroneous virus detection

### DIFF
--- a/DataTongs/DataTongs.csproj
+++ b/DataTongs/DataTongs.csproj
@@ -8,8 +8,9 @@
 	  <LangVersion>default</LangVersion>
 	  <Nullable>enable</Nullable>
 	  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+	  <PublishAot>false</PublishAot>
 
-  	  <Version>$(Version)</Version>
+	  <Version>$(Version)</Version>
 	  <FileVersion>$(Version)</FileVersion>
 	  <Company>SchemaSmith, LLC</Company>
 	  <Product>DataTongs</Product>

--- a/DataTongs481/DataTongs481.csproj
+++ b/DataTongs481/DataTongs481.csproj
@@ -8,8 +8,9 @@
 	  <LangVersion>default</LangVersion>
 	  <Nullable>enable</Nullable>
 	  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+	  <PublishAot>false</PublishAot>
 
-  	  <Version>$(Version)</Version>
+	  <Version>$(Version)</Version>
 	  <FileVersion>$(Version)</FileVersion>
 	  <Company>SchemaSmith, LLC</Company>
 	  <Product>DataTongs</Product>

--- a/Schema/Schema.csproj
+++ b/Schema/Schema.csproj
@@ -6,6 +6,8 @@
 	  <Nullable>disable</Nullable>
 	  <LangVersion>default</LangVersion>
 	  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+	  <PublishAot>false</PublishAot>
+
 	  <Version>$(Version)</Version>
 	  <FileVersion>$(Version)</FileVersion>
 	  <Company>SchemaSmith, LLC</Company>

--- a/SchemaQuench/SchemaQuench.csproj
+++ b/SchemaQuench/SchemaQuench.csproj
@@ -9,6 +9,8 @@
     <Nullable>enable</Nullable>
 	<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <UserSecretsId>ff52744b-86a4-4305-ad34-14b848e467f4</UserSecretsId>
+    <PublishAot>false</PublishAot>
+
     <Version>$(Version)</Version>
     <FileVersion>$(Version)</FileVersion>
     <Company>SchemaSmith, LLC</Company>

--- a/SchemaQuench481/SchemaQuench481.csproj
+++ b/SchemaQuench481/SchemaQuench481.csproj
@@ -9,6 +9,8 @@
     <Nullable>enable</Nullable>
 	<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <UserSecretsId>ff52744b-86a4-4305-ad34-14b848e467f4</UserSecretsId>
+    <PublishAot>false</PublishAot>
+
     <Version>$(Version)</Version>
     <FileVersion>$(Version)</FileVersion>
     <Company>SchemaSmith, LLC</Company>

--- a/SchemaTongs/SchemaTongs.csproj
+++ b/SchemaTongs/SchemaTongs.csproj
@@ -9,6 +9,7 @@
 	  <Nullable>enable</Nullable>
 	  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 	  <UserSecretsId>e821fe99-a762-4ea4-a7ea-5e64817550da</UserSecretsId>
+	  <PublishAot>false</PublishAot>
 
 	  <Version>$(Version)</Version>
 	  <FileVersion>$(Version)</FileVersion>

--- a/SchemaTongs481/SchemaTongs481.csproj
+++ b/SchemaTongs481/SchemaTongs481.csproj
@@ -9,6 +9,7 @@
 	  <Nullable>enable</Nullable>
 	  <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 	  <UserSecretsId>e821fe99-a762-4ea4-a7ea-5e64817550da</UserSecretsId>
+	  <PublishAot>false</PublishAot>
 
 	  <Version>$(Version)</Version>
 	  <FileVersion>$(Version)</FileVersion>


### PR DESCRIPTION
Turning off AOT to work around erroneous virus detection by Windows Defender