### PR TITLE
Adding support for version checks and alternate config files via command line

### DIFF
--- a/DataTongs/Program.cs
+++ b/DataTongs/Program.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Schema.Isolators;
 using Schema.Utility;
 
 namespace DataTongs;
@@ -7,6 +10,9 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        if (CommandLineParser.ContainsSwitch("v") || CommandLineParser.ContainsSwitch("ver") || CommandLineParser.ContainsSwitch("version")) ShowVersionAndExit();
+        if (CommandLineParser.ContainsSwitch("?") || CommandLineParser.ContainsSwitch("h") || CommandLineParser.ContainsSwitch("help")) ShowHelpAndExit();
+
         AppDomain.CurrentDomain.UnhandledException += UnhandledException;
         ConfigHelper.GetAppSettingsAndUserSecrets(LogFactory.GetLogger("ProgressLog").Info);
 
@@ -17,5 +23,21 @@ public static class Program
     public static void UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
         LogBackup.UnhandledExceptionLogger("DataTongs", e);
+    }
+
+    public static void ShowVersionAndExit()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        Console.WriteLine($"DataTongs - Version: {FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion}");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
+    }
+
+    public static void ShowHelpAndExit()
+    {
+        Console.WriteLine("DataTongs.exe [<command>]");
+        Console.WriteLine("  --version                Show the program version");
+        Console.WriteLine("  --ConfigFile:<filepath>  Path and file name of the config file. The default is appsettings.json in the current path.");
+        Console.WriteLine("  --help                   Show the command line options");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
     }
 }

--- a/Schema/Utility/CommandLineParser.cs
+++ b/Schema/Utility/CommandLineParser.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Schema.Utility;
+
+public static class CommandLineParser
+{
+    public static string CommandLine { get; } = ForceLeadingSpace(Environment.CommandLine);
+
+    public static List<string> Arguments
+    {
+        get
+        {
+            var result = new List<string>();
+            var pos = 0;
+            while (pos < CommandLine.Length - 1)
+            {
+                var nextPos = FindNextUnquotedSpace(CommandLine, pos);
+                if (nextPos == -1)
+                {
+                    result.Add(CommandLine.Substring(pos).Trim().Unquote());
+                    break;
+                }
+                var arg = CommandLine.Substring(pos, nextPos - pos).Trim().Unquote();
+                if (arg != string.Empty)
+                    result.Add(arg);
+                pos = FindNextNonSpace(CommandLine, nextPos);
+            }
+
+            return result;
+        }
+    }
+
+    public static Dictionary<string, string> SwitchesAndValues
+    {
+        get
+        {
+            var result = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            foreach (var argument in Arguments.Where(x => x.StartsWith("/") || x.StartsWith("-")))
+            {
+                // split into max 2 parts to handle values with embedded colon or equals
+                var parts = argument.Split(new[] { ':', '=' }, 2);
+                result[TrimKeyName(parts[0])] = parts.Length switch
+                {
+                    1 => string.Empty,
+                    2 => parts[1],
+                    _ => result[TrimKeyName(parts[0])]
+                };
+            }
+            return result;
+        }
+    }
+
+    public static bool ContainsSwitch(string switchName)
+    {
+        return SwitchesAndValues.ContainsKey(switchName);
+    }
+
+    public static string ValueOfSwitch(string switchName, string defval = "")
+    {
+        return ContainsSwitch(switchName) ? SwitchesAndValues[switchName].Trim('"', ' ') : defval;
+    }
+
+    public static int IntValueOfSwitch(string switchName, int defval = -1)
+    {
+        if (!int.TryParse(ValueOfSwitch(switchName), out var result))
+            result = defval;
+        return result;
+    }
+
+    private static string ForceLeadingSpace(string commandLine)
+    {
+        if (!commandLine.StartsWith(" "))
+            commandLine = " " + commandLine;
+        return commandLine;
+    }
+
+    private static int FindNextNonSpace(string s, int startPos)
+    {
+        var curPos = startPos;
+        while (s[curPos] == ' ' && curPos < s.Length - 1)
+            curPos++;
+        return curPos;
+    }
+
+    private static int FindNextUnquotedSpace(string s, int startPos)
+    {
+        var firstQuote = s.IndexOf('"', startPos);
+        var nextQuote = s.IndexOf('"', firstQuote + 1);
+        var nextSpace = s.IndexOf(' ', startPos);
+        if (nextSpace == -1) return nextSpace;
+        while (nextSpace > firstQuote && nextSpace < nextQuote)
+            nextSpace = FindNextUnquotedSpace(s, nextQuote + 1);
+
+        return nextSpace;
+    }
+
+    private static string TrimKeyName(string s)
+    {
+        return s.TrimStart('/').TrimStart('-');
+    }
+}

--- a/Schema/Utility/ConfigHelper.cs
+++ b/Schema/Utility/ConfigHelper.cs
@@ -31,7 +31,8 @@ public static class ConfigHelper
             if (config != null) return config;
 
             var builder = new ConfigurationBuilder();
-            builder.AddJsonFile("appsettings.json")
+            var settingsFile = CommandLineParser.ValueOfSwitch("ConfigFile", null) ?? "appsettings.json";
+            builder.AddJsonFile(settingsFile)
 #if DEBUG
                 .AddUserSecrets(Assembly.GetCallingAssembly())
 #endif

--- a/Schema/Utility/StringExtensions.cs
+++ b/Schema/Utility/StringExtensions.cs
@@ -20,6 +20,14 @@ public static class StringExtensions
 
     public static string ReplaceIgnoringCase(this string source, string find, string replace) => Regex.Replace(source, Regex.Escape(find), replace, RegexOptions.IgnoreCase);
 
+    public static string Unquote(this string value)
+    {
+        var result = value.Trim();
+        if (result.StartsWith("\"") && result.EndsWith("\""))
+            return result.Trim('"');
+        return value;
+    }
+
     public static Stream ToStream(this string str)
     {
         MemoryStream stream = new MemoryStream();

--- a/SchemaQuench/Program.cs
+++ b/SchemaQuench/Program.cs
@@ -1,5 +1,8 @@
-﻿using Schema.Utility;
-using System;
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Schema.Isolators;
+using Schema.Utility;
 
 namespace SchemaQuench;
 
@@ -7,6 +10,9 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        if (CommandLineParser.ContainsSwitch("v") || CommandLineParser.ContainsSwitch("ver") || CommandLineParser.ContainsSwitch("version")) ShowVersionAndExit();
+        if (CommandLineParser.ContainsSwitch("?") || CommandLineParser.ContainsSwitch("h") || CommandLineParser.ContainsSwitch("help")) ShowHelpAndExit();
+
         var skipKindlingForge = args.Length > 0 && args[0] == "SkipKindlingForge";
         AppDomain.CurrentDomain.UnhandledException += UnhandledException;
         ConfigHelper.GetAppSettingsAndUserSecrets(LogFactory.GetLogger("ProgressLog").Info);
@@ -17,5 +23,21 @@ public static class Program
     public static void UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
         LogBackup.UnhandledExceptionLogger("SchemaQuench", e);
+    }
+
+    public static void ShowVersionAndExit()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        Console.WriteLine($"SchemaQuench - Version: {FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion}");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
+    }
+
+    public static void ShowHelpAndExit()
+    {
+        Console.WriteLine("SchemaQuench.exe [<command>]");
+        Console.WriteLine("  --version                Show the program version");
+        Console.WriteLine("  --ConfigFile:<filepath>  Path and file name of the config file. The default is appsettings.json in the current path.");
+        Console.WriteLine("  --help                   Show the command line options");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
     }
 }

--- a/SchemaTongs/Program.cs
+++ b/SchemaTongs/Program.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Schema.Isolators;
 using Schema.Utility;
 
 namespace SchemaTongs;
@@ -7,6 +10,9 @@ public static class Program
 {
     public static void Main(string[] args)
     {
+        if (CommandLineParser.ContainsSwitch("v") || CommandLineParser.ContainsSwitch("ver") || CommandLineParser.ContainsSwitch("version")) ShowVersionAndExit();
+        if (CommandLineParser.ContainsSwitch("?") || CommandLineParser.ContainsSwitch("h") || CommandLineParser.ContainsSwitch("help")) ShowHelpAndExit();
+
         AppDomain.CurrentDomain.UnhandledException += UnhandledException;
         ConfigHelper.GetAppSettingsAndUserSecrets(LogFactory.GetLogger("ProgressLog").Info);
 
@@ -17,5 +23,21 @@ public static class Program
     public static void UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
         LogBackup.UnhandledExceptionLogger("SchemaTongs", e);
+    }
+
+    public static void ShowVersionAndExit()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        Console.WriteLine($"SchemaTongs - Version: {FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion}");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
+    }
+
+    public static void ShowHelpAndExit()
+    {
+        Console.WriteLine("SchemaTongs.exe [<command>]");
+        Console.WriteLine("  --version                Show the program version");
+        Console.WriteLine("  --ConfigFile:<filepath>  Path and file name of the config file. The default is appsettings.json in the current path.");
+        Console.WriteLine("  --help                   Show the command line options");
+        EnvironmentWrapper.GetFromFactory().Exit(0);
     }
 }

--- a/SchemaTongs/appsettings.json
+++ b/SchemaTongs/appsettings.json
@@ -23,6 +23,7 @@
         "Catalogs": true,
         "StopLists": true,
         "DDLTriggers": true,
-        "XMLSchemaCollections": true
+        "XMLSchemaCollections": true,
+        "ObjectList": ""
     }
 }


### PR DESCRIPTION
- Check version from command line (SchemaTongs, SchemaQuench, & DataTongs)
- Specify alternate config file from command line (SchemaTongs, SchemaQuench, & DataTongs)
- Support specific object list in the config file for SchemaTongs