### PR TITLE
fix(token-helper): platform-aware BinaryFile emits correct PostgreSQL BYTEA literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ For full release details and download links, see [GitHub Releases](https://githu
 - **Backslash escaping for MySQL** — Platform-specific escaping (SQL Server/PostgreSQL don't need it)
 - **TrustServerCertificate default** — Removed from platform-agnostic defaults (broke MySQL connections)
 - **Docker release image UID** — Fixed UID 1000 conflict with Ubuntu 24.04 base image
+- **`<*BinaryFile*>` PostgreSQL output** — Resolver now emits PostgreSQL `BYTEA` literal syntax (`E'\\x...'::bytea`) when the product platform is PostgreSQL; SQL Server and MySQL continue to receive `0x<hex>` literals. Previously emitted `0x<hex>` unconditionally, which parses as an invalid integer on PostgreSQL and silently broke binary token insertion into BYTEA columns.
 
 ## [v1.1.8](https://github.com/Schema-Smith/SchemaSmithyFree/releases/tag/v1.1.8) — 2026-02-08
 

--- a/Schema/Domain/Product.cs
+++ b/Schema/Domain/Product.cs
@@ -109,7 +109,7 @@ namespace Schema.Domain
             var product = JsonHelper.ProductLoad(productFilePath);
             product.FilePath = productFilePath;
             OverrideProductScriptTokens(config, product);
-            TokenHelper.ResolveFileTokens(product.ScriptTokens, schemaPackagePath);
+            TokenHelper.ResolveFileTokens(product.ScriptTokens, schemaPackagePath, product.Platform);
             product.ScriptTokens.Add("ProductName", product.Name);
 
             product.InstanceLoad();

--- a/Schema/Domain/Template.cs
+++ b/Schema/Domain/Template.cs
@@ -177,7 +177,7 @@ namespace Schema.Domain
             foreach (var token in template.ScriptTokens)
                 template.LoggableTokens.Add(token.Key, token.Value);
 
-            TokenHelper.ResolveFileTokens(template.ScriptTokens, templatePath);
+            TokenHelper.ResolveFileTokens(template.ScriptTokens, templatePath, product.Platform);
 
             // Merge template and product script tokens — template takes precedence
             var scriptTokens = template.ScriptTokens

--- a/Schema/Schema.IntegrationTests/PostgreSQL/BinaryFileTokenIntegrationTests.cs
+++ b/Schema/Schema.IntegrationTests/PostgreSQL/BinaryFileTokenIntegrationTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using NUnit.Framework;
+using Schema.DataAccess;
+using Schema.Domain;
+using Schema.Utility;
+
+namespace Schema.IntegrationTests.PostgreSQL;
+
+/// <summary>
+/// End-to-end proof that <*BinaryFile*> resolution produces PostgreSQL BYTEA literal syntax
+/// that a live PG engine actually accepts. Writes a real binary file to disk, resolves the
+/// token via TokenHelper with Platform.PostgreSQL, substitutes the resolved value into an
+/// INSERT statement, runs it against a real BYTEA column, and verifies the round-tripped
+/// bytes match the original file content exactly.
+/// </summary>
+[Category("PostgreSQL")]
+[TestFixture]
+[Category("Integration")]
+public class BinaryFileTokenIntegrationTests
+{
+    private IDbConnection _connection = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _connection = DbConnectionFactory.ForPlatform(Platform.PostgreSQL).GetDbConnection(FixtureSetup.GetMainDbConnectionString());
+        _connection.Open();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _connection?.Close();
+        _connection?.Dispose();
+    }
+
+    [Test]
+    public void BinaryFileToken_RoundTripsThroughPostgresByteaColumn()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"schemasmith-bytea-it-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var fileRelativePath = "payload.bin";
+        var filePath = Path.Combine(tempDir, fileRelativePath);
+
+        // Representative byte spread: null byte, low ASCII, high ASCII, 0xFF — forces correct hex encoding
+        // across the full 0x00-0xFF range rather than a lucky middle-of-range sample.
+        var originalBytes = new byte[] { 0x00, 0x0C, 0xFF, 0x7F, 0x80, 0x01, 0x89, 0x50, 0x4E, 0x47 };
+        File.WriteAllBytes(filePath, originalBytes);
+
+        var tableName = $"_test_bytea_{Guid.NewGuid():N}"[..40];
+        using var command = _connection.CreateCommand();
+
+        try
+        {
+            command.CommandText = $@"CREATE TABLE ""public"".""{tableName}"" (
+    ""id"" INT PRIMARY KEY,
+    ""payload"" BYTEA NOT NULL
+)";
+            command.ExecuteNonQuery();
+
+            var tokens = new Dictionary<string, string>
+            {
+                { "MyBinary", $"{TokenHelper.BinaryFileTag}{fileRelativePath}" }
+            };
+
+            TokenHelper.ResolveFileTokens(tokens, tempDir, Platform.PostgreSQL);
+
+            var resolved = tokens["MyBinary"];
+            // PG E-string: the `\\` in the literal is parsed by PG as a single backslash,
+            // giving it the `\x<hex>` form it needs for BYTEA input.
+            Assert.That(resolved, Does.StartWith(@"E'\\x"));
+            Assert.That(resolved, Does.EndWith("'::bytea"));
+
+            command.CommandText = $@"INSERT INTO ""public"".""{tableName}"" (""id"", ""payload"") VALUES (1, {resolved})";
+            command.ExecuteNonQuery();
+
+            command.CommandText = $@"SELECT ""payload"" FROM ""public"".""{tableName}"" WHERE ""id"" = 1";
+            var roundTripped = (byte[])command.ExecuteScalar()!;
+
+            Assert.That(roundTripped, Is.EqualTo(originalBytes),
+                "Bytes read back from BYTEA column must match the original file content exactly.");
+        }
+        finally
+        {
+            command.CommandText = $@"DROP TABLE IF EXISTS ""public"".""{tableName}""";
+            command.ExecuteNonQuery();
+
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/Schema/Schema.UnitTests/Utility/TokenHelperTests.cs
+++ b/Schema/Schema.UnitTests/Utility/TokenHelperTests.cs
@@ -37,14 +37,14 @@ public class TokenHelperTests
         lock (FactoryContainer.SharedLockObject)
         {
             FactoryContainer.Register(mockFileWrapper);
-            TokenHelper.ResolveFileTokens(tokens, basePath);
+            TokenHelper.ResolveFileTokens(tokens, basePath, Platform.SqlServer);
             Assert.That(tokens["MyTableData"], Is.EqualTo(fileContent));
             FactoryContainer.Clear();
         }
     }
 
     [Test]
-    public void ShouldResolveBinaryFileTokens()
+    public void ShouldResolveBinaryFileTokens_SqlServer_EmitsHexWith0xPrefix()
     {
         var basePath = "C:/Projects/MyMetadata";
         var tokens = new Dictionary<string, string>
@@ -62,8 +62,56 @@ public class TokenHelperTests
         lock (FactoryContainer.SharedLockObject)
         {
             FactoryContainer.Register(mockFileWrapper);
-            TokenHelper.ResolveFileTokens(tokens, basePath);
+            TokenHelper.ResolveFileTokens(tokens, basePath, Platform.SqlServer);
             Assert.That(tokens["BinaryContent"], Is.EqualTo($"0x{BitConverter.ToString(fileContent).Replace("-", "")}"));
+            FactoryContainer.Clear();
+        }
+    }
+
+    [Test]
+    public void ShouldResolveBinaryFileTokens_MySQL_EmitsHexWith0xPrefix()
+    {
+        var basePath = "C:/Projects/MyMetadata";
+        var tokens = new Dictionary<string, string>
+        {
+            {"MainDB", "MainDB"},
+            {"BinaryContent", "<*BinaryFile*>Files/MyBinary.dll"}
+        };
+        var filePath = Path.Combine(basePath, "Files/MyBinary.dll");
+        var fileContent = new byte[] {12, 255, 6, 55, 77, 125};
+
+        var mockFileWrapper = Substitute.For<IFile>();
+        mockFileWrapper.Exists(filePath).Returns(true);
+        mockFileWrapper.ReadAllBytes(filePath).Returns(fileContent);
+        lock (FactoryContainer.SharedLockObject)
+        {
+            FactoryContainer.Register(mockFileWrapper);
+            TokenHelper.ResolveFileTokens(tokens, basePath, Platform.MySQL);
+            Assert.That(tokens["BinaryContent"], Is.EqualTo($"0x{BitConverter.ToString(fileContent).Replace("-", "")}"));
+            FactoryContainer.Clear();
+        }
+    }
+
+    [Test]
+    public void ShouldResolveBinaryFileTokens_PostgreSQL_EmitsByteaEscapedHex()
+    {
+        var basePath = "C:/Projects/MyMetadata";
+        var tokens = new Dictionary<string, string>
+        {
+            {"MainDB", "MainDB"},
+            {"BinaryContent", "<*BinaryFile*>Files/MyBinary.dll"}
+        };
+        var filePath = Path.Combine(basePath, "Files/MyBinary.dll");
+        var fileContent = new byte[] {12, 255, 6, 55, 77, 125};
+
+        var mockFileWrapper = Substitute.For<IFile>();
+        mockFileWrapper.Exists(filePath).Returns(true);
+        mockFileWrapper.ReadAllBytes(filePath).Returns(fileContent);
+        lock (FactoryContainer.SharedLockObject)
+        {
+            FactoryContainer.Register(mockFileWrapper);
+            TokenHelper.ResolveFileTokens(tokens, basePath, Platform.PostgreSQL);
+            Assert.That(tokens["BinaryContent"], Is.EqualTo($"E'\\\\x{BitConverter.ToString(fileContent).Replace("-", "")}'::bytea"));
             FactoryContainer.Clear();
         }
     }
@@ -82,7 +130,7 @@ public class TokenHelperTests
         lock (FactoryContainer.SharedLockObject)
         {
             FactoryContainer.Register(mockFileWrapper);
-            var ex = Assert.Throws<Exception>(() => TokenHelper.ResolveFileTokens(tokens, basePath));
+            var ex = Assert.Throws<Exception>(() => TokenHelper.ResolveFileTokens(tokens, basePath, Platform.SqlServer));
             Assert.That(ex.Message, Does.Contain("missing file"));
             FactoryContainer.Clear();
         }
@@ -156,7 +204,7 @@ public class TokenHelperTests
         lock (FactoryContainer.SharedLockObject)
         {
             FactoryContainer.Register(mockFileWrapper);
-            TokenHelper.ResolveFileTokens(tokens, basePath);
+            TokenHelper.ResolveFileTokens(tokens, basePath, Platform.SqlServer);
             Assert.That(tokens["MyQueryResult"], Is.EqualTo($"{TokenHelper.QueryTag}{fileContent}"));
             FactoryContainer.Clear();
         }

--- a/Schema/Utility/TokenHelper.cs
+++ b/Schema/Utility/TokenHelper.cs
@@ -26,11 +26,18 @@ public static class TokenHelper
 
     public static void ResolveFileTokens(Dictionary<string, string> tokens, string basePath, Platform platform)
     {
-        _ = platform; // RED phase: signature threaded through callers; GREEN commit adds per-platform dispatch.
+        // PostgreSQL BYTEA needs an E-string-escaped hex literal with an explicit cast; SQL Server VARBINARY and
+        // MySQL BLOB both accept 0x<hex> directly. Pattern mirrors GetDropTempTablesScript's platform branching.
+        var (binaryPrefix, binarySuffix) = platform switch
+        {
+            Platform.PostgreSQL => (@"E'\\x", "'::bytea"),
+            _ => ("0x", "")
+        };
+
         var tokenErrors = new List<string>();
-        ResolveFileTokensByTag(tokens, basePath, tokenErrors, FileTag, "", fileName => ProductFileWrapper.GetFromFactory().ReadAllText(fileName));
-        ResolveFileTokensByTag(tokens, basePath, tokenErrors, BinaryFileTag, "0x", fileName => BitConverter.ToString(ProductFileWrapper.GetFromFactory().ReadAllBytes(fileName)).Replace("-", ""));
-        ResolveFileTokensByTag(tokens, basePath, tokenErrors, QueryFileTag, QueryTag, fileName => ProductFileWrapper.GetFromFactory().ReadAllText(fileName));
+        ResolveFileTokensByTag(tokens, basePath, tokenErrors, FileTag, "", "", fileName => ProductFileWrapper.GetFromFactory().ReadAllText(fileName));
+        ResolveFileTokensByTag(tokens, basePath, tokenErrors, BinaryFileTag, binaryPrefix, binarySuffix, fileName => BitConverter.ToString(ProductFileWrapper.GetFromFactory().ReadAllBytes(fileName)).Replace("-", ""));
+        ResolveFileTokensByTag(tokens, basePath, tokenErrors, QueryFileTag, QueryTag, "", fileName => ProductFileWrapper.GetFromFactory().ReadAllText(fileName));
         if (tokenErrors.Count == 0) return;
         throw new Exception(string.Join("\r\n", tokenErrors));
     }
@@ -193,7 +200,7 @@ public static class TokenHelper
         return tables.FirstOrDefault(t => $"{t.Name}".Replace("\"", "").Replace("`", "").EqualsIgnoringCase(tableRef.Replace("\"", "").Replace("`", "")));
     }
 
-    private static void ResolveFileTokensByTag(Dictionary<string, string> tokens, string basePath, List<string> tokenErrors, string tag, string contentPrefix, Func<string, string> readFile)
+    private static void ResolveFileTokensByTag(Dictionary<string, string> tokens, string basePath, List<string> tokenErrors, string tag, string contentPrefix, string contentSuffix, Func<string, string> readFile)
     {
         var fileTokens = tokens.Where(t => t.Value.StartsWithIgnoringCase(tag)).ToList();
         if (fileTokens.Count == 0) return;
@@ -210,7 +217,7 @@ public static class TokenHelper
                 if (ProductFileWrapper.GetFromFactory().Exists(fileName))
                     try
                     {
-                        results[t.Key] = $"{contentPrefix}{readFile.Invoke(fileName)}";
+                        results[t.Key] = $"{contentPrefix}{readFile.Invoke(fileName)}{contentSuffix}";
                     }
                     catch (Exception e)
                     {

--- a/Schema/Utility/TokenHelper.cs
+++ b/Schema/Utility/TokenHelper.cs
@@ -24,8 +24,9 @@ public static class TokenHelper
     public const string SpecificMaterializedViewTag = "<*SpecificMaterializedView*>";
     public const string SpecificIndexedViewTag = "<*SpecificIndexedView*>";
 
-    public static void ResolveFileTokens(Dictionary<string, string> tokens, string basePath)
+    public static void ResolveFileTokens(Dictionary<string, string> tokens, string basePath, Platform platform)
     {
+        _ = platform; // RED phase: signature threaded through callers; GREEN commit adds per-platform dispatch.
         var tokenErrors = new List<string>();
         ResolveFileTokensByTag(tokens, basePath, tokenErrors, FileTag, "", fileName => ProductFileWrapper.GetFromFactory().ReadAllText(fileName));
         ResolveFileTokensByTag(tokens, basePath, tokenErrors, BinaryFileTag, "0x", fileName => BitConverter.ToString(ProductFileWrapper.GetFromFactory().ReadAllBytes(fileName)).Replace("-", ""));

--- a/docs/end-user/reference/script-tokens.md
+++ b/docs/end-user/reference/script-tokens.md
@@ -202,7 +202,13 @@ For test images, certificate blobs, signing keys -- anything you need to inject 
 INSERT dbo.BrandAssets(Name, Image) VALUES('Default', {{DefaultLogo}});
 ```
 
-The token resolves to `0x89504E47...` -- a SQL Server `VARBINARY` literal, equally valid as a PostgreSQL `BYTEA` literal in the appropriate syntax.
+The token resolves to the platform-appropriate binary literal form automatically, chosen from the product's `Platform`:
+
+- **SQL Server** — `0x89504E47...` (`VARBINARY` literal)
+- **MySQL** — `0x89504E47...` (`BLOB` literal)
+- **PostgreSQL** — `E'\\x89504E47...'::bytea` (`BYTEA` literal with escape-string + explicit cast)
+
+The same `<*BinaryFile*>` token works across all three engines with no per-environment editing. The resolver reads the file once and emits the correct literal form for the target; your SQL script just sees `{{DefaultLogo}}` land as whatever that engine will accept.
 
 ### Example — query the target server for a value
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                 
  `<*BinaryFile*>` token resolution previously emitted `0x<hex>` unconditionally, regardless of target platform. On PostgreSQL this parses as an invalid integer literal and silently broke binary token insertion 
  into BYTEA columns. The resolver now dispatches the literal form per platform:
                                                                                                                                                                                                                   
  |---|---|---|                                                             
  | SQL Server | `0x<hex>` | `VARBINARY` (unchanged) |                                                                                                                                                           
  | MySQL | `0x<hex>` | `BLOB` (unchanged) |          
  | PostgreSQL | `E'\\x<hex>'::bytea` | `BYTEA` (new) |                                                                                                                                                            
                                                                                                                                                                                                                   
  Same `<*BinaryFile*>` token works across all three engines with no per-environment editing.                                                                                                                      
                                                                                                                                                                                                                   
  ## The bug                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  `Schema/Utility/TokenHelper.cs:31` (pre-fix) had the `0x` prefix hardcoded into `ResolveFileTokensByTag`. No platform branch. Truth table for `VALUES (0xDEADBEEF)` against a binary column:                   
                                                                                                                                                                                                                   
  | Platform | Result |                                                                                                                                                                                          
  |---|---|                                                                                                                                                                                                        
  | SQL Server `VARBINARY` | Works (valid literal) |                        
  | MySQL `BLOB` | Works (accepted via loose type coercion) |                                                                                                                                                      
  | PostgreSQL `BYTEA` | **Fails** — `0x<hex>` parses as invalid integer; PG expects `E'\\x<hex>'::bytea` or `decode('<hex>', 'hex')::bytea` |
                                                                                                                                                                                                                   
  Surfaced during a schemasmith.com script-token-mechanics.html refresh pre-check audit against canonical `reference/script-tokens.md`, which had also claimed the output was "equally valid as a PostgreSQL       
  `BYTEA` literal in the appropriate syntax" — that claim was fabricated. Canonical prose is corrected in the same PR.                                                                                             
                                                                                                                                                                                                                   
  ## The fix                                                                                                                                                                                                       
                                                                            
  `TokenHelper.ResolveFileTokens` gained a required `Platform platform` parameter. Internal BinaryFile dispatch uses a switch expression (pattern matches the existing `GetDropTempTablesScript` platform branching
   in the same file):                                                                                                                                                                                              
                                         
  ```csharp                                                                                                                                                                                                        
  var (binaryPrefix, binarySuffix) = platform switch                        
  {                                                        
      Platform.PostgreSQL => (@"E'\\x", "'::bytea"),
      _ => ("0x", "")                               
  };                                                                                                                                                                                                               
                                                                                                                                                                                                                   
  PG BYTEA syntax chose E'\\x<hex>'::bytea over alternatives:                                                                                                                                                      
  - E'\\x<hex>' (no explicit cast — works in INSERT via column-type inference, fragile elsewhere)                                                                                                                  
  - decode('<hex>', 'hex')::bytea (function-based, more verbose)                                                                                                                                                   
  - '\\x<hex>'::bytea (depends on standard_conforming_strings GUC being on)                                                                                                                                        
                                                                                                                                                                                                                   
  The chosen form is GUC-independent (E-string escaping is always correct) and the explicit ::bytea cast makes the literal unambiguous in any SQL context, not just INSERT-to-BYTEA-column.                        
                                                                                                                                                                                                                   
  Breaking change notice                                                                                                                                                                                           
                                                                                                                                                                                                                   
  TokenHelper.ResolveFileTokens signature changed from (tokens, basePath) to (tokens, basePath, platform). This is a breaking API change on SchemaSmith.Schema NuGet.                                              
                                                                            
  Community callers updated in this PR:                                                                                                                                                                            
  - Schema/Domain/Product.cs:112                                            
  - Schema/Domain/Template.cs:180                                                                                                                                                                                  
                                                                            
  External consumers (carry-back required):                                                                                                                                                                        
  - SchemaForge SchemaHammer/Services/QuenchService.cs — lines 271 and 285 call ResolveFileTokens from GetScriptTokens(Template?, Product, ...) where product.Platform is already in scope (used on adjacent lines 
  272 and 286 for ResolveQueryTokens). Fix-up is two single-argument additions. After this PR merges, SchemaForge follow-up: dotnet pack Schema/Schema.csproj -c Release -o <SchemaForge-packages-path> + the      
  two-line QuenchService.cs edit. Carry-back filed in the Community enterprise-carryback-roadmap.                                                                                                                  
  - AskForge: zero code consumers (grep confirmed). No follow-up needed.                                                                                                                                           
                                                                            
  A soft-deprecation overload ([Obsolete] with a Platform.SqlServer default) was considered and rejected: TreatWarningsAsErrors would break SchemaForge's build on the next rebuild anyway, and any default        
  fallback reintroduces the exact bug for non-SQL-Server external consumers.                                                                                                                                       
                                                                                                                                                                                                                   
  Test evidence                                                                                                                                                                                                    
                                                                            
  All tests run locally on macOS arm64 with .NET 10.0.107.                                                                                                                                                         
                                         
  Unit tests — 1504/1504 pass across 4 projects (baseline was 1502, +2 new BinaryFile tests):                                                                                                                      
                                                                            
  ┌────────────────────────┬────────┬───────┐                                                                                                                                                                      
  │        Project         │ Passed │ Total │                               
  ├────────────────────────┼────────┼───────┤              
  │ Schema.UnitTests       │ 1128   │ 1128  │
  ├────────────────────────┼────────┼───────┤
  │ SchemaQuench.UnitTests │ 78     │ 78    │                                                                                                                                                                      
  ├────────────────────────┼────────┼───────┤                                                                                                                                                                      
  │ SchemaTongs.UnitTests  │ 216    │ 216   │                                                                                                                                                                      
  ├────────────────────────┼────────┼───────┤                                                                                                                                                                      
  │ DataTongs.UnitTests    │ 82     │ 82    │                               
  └────────────────────────┴────────┴───────┘                                                                                                                                                                      
                                         
  Pre-change per-platform BinaryFile coverage: 1 test (SQL Server shape only). MySQL: 0. PostgreSQL: 0.                                                                                                            
  Post-change: 3 tests, one per platform, covering the three distinct expected outputs.
                                                                                                                                                                                                                   
  Integration test — 1/1 pass. New Schema.IntegrationTests/PostgreSQL/BinaryFileTokenIntegrationTests.cs writes 10 bytes to a temp file (spanning 0x00-0xFF including nulls and high-bit), resolves <*BinaryFile*> 
  via TokenHelper.ResolveFileTokens(..., Platform.PostgreSQL), substitutes the resolved value into an INSERT INTO ... VALUES (1, <resolved>) against a per-test BYTEA table on a live postgres:latest container,   
  and asserts byte-for-byte round-trip equality on the SELECT. Proves the emitted literal is actually accepted by PG and that bytes don't corrupt across the full byte range (including null bytes, which are      
  common in real binary content).                                           
                                                           
  SQL Server and MySQL BinaryFile integration tests not added: their output is unchanged from before the fix, the unit tests lock in the expected string shape, and the pre-existing                               
  MergeScriptHelperIntegrationTests exercise the broader binary-into-VARBINARY/BLOB path. Easy follow-up if coverage becomes load-bearing.
                                                                                                                                                                                                                   
  Commits (TDD discipline preserved in history)                                                                                                                                                                    
                                                           
  1. 5e754a0 test(token-helper): add per-platform BinaryFile red tests                                                                                                                                             
  2. f7dbc8b fix(token-helper): emit platform-appropriate BinaryFile literal syntax
  3. 004f0c9 test(token-helper): integration test proves BinaryFile round-trips through PostgreSQL BYTEA column                                                                                                    
  4. 4e7fce8 docs(script-tokens): describe platform-aware BinaryFile output                                                                                                                                        
  5. 53a3c81 docs(changelog): note BinaryFile PostgreSQL output fix                                                                                                                                                
                                                                                                                                                                                                                   
  Test plan                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  - Unit suite: 1504/1504 pass across all 4 unit projects                                                                                                                                                          
  - Integration: new PG BinaryFile round-trip test passes against postgres:latest
  - Zero build warnings (TreatWarningsAsErrors active)                                                                                                                                                             
  - Canonical doc + CHANGELOG updated                                                                                                                                                                              
  - Reviewer: sanity-check the PG BYTEA literal choice (E'\\x<hex>'::bytea vs alternatives)                                                                                                                        
  - Reviewer: confirm the breaking-change trade-off is acceptable (vs the soft-deprecation overload)    