### PR TITLE
Add retry loop to SQL Server FTS install step in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,11 +88,25 @@ jobs:
     steps:
       - name: Install Full-Text Search on SQL Server
         run: |
-          docker exec -u 0 mssql apt-get update
-          docker exec -u 0 mssql apt-get install -yq curl systemctl
-          docker exec -u 0 mssql curl https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list -o /etc/apt/sources.list.d/mssql-server-2019.list
-          docker exec -u 0 mssql apt-get update
-          docker exec -u 0 mssql apt-get install -y mssql-server-fts
+          retry() {
+            local n=1 max=3 delay=10
+            while true; do
+              if "$@"; then return 0; fi
+              if [ $n -ge $max ]; then
+                echo "Command failed after $n attempts: $*" >&2
+                return 1
+              fi
+              echo "Attempt $n failed: $*  — retrying in ${delay}s" >&2
+              sleep $delay
+              n=$((n+1))
+              delay=$((delay*2))
+            done
+          }
+          retry docker exec -u 0 mssql apt-get update
+          retry docker exec -u 0 mssql apt-get install -yq curl systemctl
+          retry docker exec -u 0 mssql curl -fsSL https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list -o /etc/apt/sources.list.d/mssql-server-2019.list
+          retry docker exec -u 0 mssql apt-get update
+          retry docker exec -u 0 mssql apt-get install -y mssql-server-fts
           docker container restart mssql
 
       - name: Wait for SQL Server to be ready


### PR DESCRIPTION
The Install Full-Text Search step inside the SQL Server container is flaky: apt-get update / install and the packages.microsoft.com curl occasionally fail with exit 100, breaking unrelated PR merges (e.g. run 25339940624 on 7bdda46). The base image is mcr.microsoft.com/mssql/ server:2019-CU27-ubuntu-20.04, whose Ubuntu 20.04 archive has been post-EOL since April 2025 and is increasingly unreliable.

Wrap each apt-get/curl call in a retry helper (3 attempts, 10s/20s exponential backoff) and add -fsSL to the curl so transient HTTP 5xx fails the attempt instead of writing an HTML error page into the apt sources list. The trailing docker container restart stays unwrapped.