### PR TITLE
Fix macOS/Windows ICU host-config + SQL Server computed-column idempotency 

### DIFF
--- a/DataTongs/DataTongs.csproj
+++ b/DataTongs/DataTongs.csproj
@@ -31,10 +31,14 @@
 	</ItemGroup>
 
 	<!-- Bundle ICU into self-contained Linux publish output so the CLI works on minimal
-	     containers (ubuntu:24.04, fedora:latest) without system libicu. Other RIDs
-	     (Windows, macOS) get nothing extra — system ICU is reliably present and is
-	     preferred at load time. ICU version is centralized in Directory.Build.props. -->
-	<ItemGroup>
+	     containers (ubuntu:24.04, fedora:latest) without system libicu. Linux-only:
+	     setting AppLocalIcu unconditionally forces app-local lookup on every host,
+	     and Microsoft.ICU.ICU4C.Runtime only ships Linux dylibs — so on macOS/Windows
+	     the runtime hard-fails ("Failed to load app-local ICU: libicuuc...") instead
+	     of falling back to system ICU. Gate on RuntimeIdentifier so non-Linux RIDs
+	     (osx-*, win-*) and framework-dependent builds use system ICU as intended.
+	     ICU version is centralized in Directory.Build.props. -->
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(IcuVersion)" />
 		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
 	</ItemGroup>

--- a/Schema/Schema.UnitTests/Utility/ForgeKindlerTests.cs
+++ b/Schema/Schema.UnitTests/Utility/ForgeKindlerTests.cs
@@ -93,7 +93,7 @@ public class ForgeKindlerTests
         var postgres = ForgeKindler.GetKindlingScriptNames(Platform.PostgreSQL);
         var mysql = ForgeKindler.GetKindlingScriptNames(Platform.MySQL);
 
-        Assert.That(sqlServer.Length, Is.EqualTo(18)); // was 14, adding 4 indexed view scripts
+        Assert.That(sqlServer.Length, Is.EqualTo(19)); // was 18, +1 for fn_NormalizeExpression
         Assert.That(postgres.Length, Is.EqualTo(22));
         Assert.That(mysql.Length, Is.EqualTo(15));
     }

--- a/Schema/Scripts/SqlServer/ParseTableJsonIntoTempTables.sql
+++ b/Schema/Scripts/SqlServer/ParseTableJsonIntoTempTables.sql
@@ -43,7 +43,19 @@
   
   RAISERROR('Parse Columns from Json', 10, 100) WITH NOWAIT
   DROP TABLE IF EXISTS #Columns
-  SELECT t.[Schema], t.[Name] AS [TableName], [ColumnName] = SchemaSmith.fn_SafeBracketWrap(c.[ColumnName]), [DataType] = REPLACE(c.[DataType], 'ROWVERSION', 'TIMESTAMP'), [Nullable] = ISNULL(c.[Nullable], 0), 
+  SELECT t.[Schema], t.[Name] AS [TableName], [ColumnName] = SchemaSmith.fn_SafeBracketWrap(c.[ColumnName]),
+         -- Canonicalize the JSON DataType so the live-vs-declared comparison
+         -- in ModifiedTableQuench (which builds USER_TYPE + DATETIME_PRECISION
+         -- as e.g. "DATETIME2(7)") matches a JSON-declared "DATETIME2" without
+         -- explicit precision. SQL Server defaults DATETIME2 / TIME /
+         -- DATETIMEOFFSET to precision 7 — without canonicalization, every
+         -- re-quench against a column declared with the default precision sees
+         -- false drift and emits a destructive ALTER COLUMN that cascades to
+         -- any dependent computed columns and indexes.
+         [DataType] = CASE WHEN UPPER(LTRIM(RTRIM(REPLACE(c.[DataType], 'ROWVERSION', 'TIMESTAMP')))) IN ('DATETIME2', 'TIME', 'DATETIMEOFFSET')
+                            THEN UPPER(LTRIM(RTRIM(REPLACE(c.[DataType], 'ROWVERSION', 'TIMESTAMP')))) + '(7)'
+                            ELSE REPLACE(c.[DataType], 'ROWVERSION', 'TIMESTAMP') END,
+         [Nullable] = ISNULL(c.[Nullable], 0),
          c.[Default], c.[CheckExpression], c.[ComputedExpression], [Persisted] = ISNULL(c.[Persisted], 0),
          [Sparse] = ISNULL(c.[Sparse], 0), [Collation] = RTRIM(ISNULL(c.[Collation], '')), [DataMaskFunction] = RTRIM(ISNULL(c.[DataMaskFunction], '')), 
          [EncryptionType] = ISNULL(c.[EncryptionType], 'NONE'), [EncryptionKey] = RTRIM(ISNULL(c.[EncryptionKey], '')), [EncryptionAlgorithm] = RTRIM(ISNULL(c.[EncryptionAlgorithm], '')),
@@ -58,6 +70,7 @@
          SchemaSmith.fn_SafeBracketWrap(c.[ColumnName]) + ' ' +
          -- For computed columns only the expression is needed
          CASE WHEN RTRIM(ISNULL([ComputedExpression], '')) <> '' THEN 'AS (' + ComputedExpression + ')' + CASE WHEN ISNULL(c.[Persisted], 0) = 1 THEN ' PERSISTED' ELSE '' END
+                                                                                                     + CASE WHEN ISNULL(c.[Persisted], 0) = 1 AND ISNULL(c.[Nullable], 1) = 0 THEN ' NOT NULL' ELSE '' END
               -- Otherwise build the column definition
               ELSE UPPER(REPLACE(c.[DataType], 'ROWVERSION', 'TIMESTAMP')) + 
                    CASE WHEN RTRIM(ISNULL([Collation], '')) NOT IN ('IGNORE', '') THEN ' COLLATE ' + [Collation] ELSE '' END +                   

--- a/Schema/Scripts/SqlServer/SchemaSmith.ModifiedTableQuench.sql
+++ b/Schema/Scripts/SqlServer/SchemaSmith.ModifiedTableQuench.sql
@@ -114,10 +114,11 @@ BEGIN TRY
   DROP TABLE IF EXISTS #ColumnChanges
   SELECT c.[Schema], c.[TableName], c.[ColumnName],
          -- For computed columns, only the expression is needed
-         CASE WHEN RTRIM(ISNULL([ComputedExpression], '')) <> '' 
+         CASE WHEN RTRIM(ISNULL([ComputedExpression], '')) <> ''
               THEN 'AS (' + ComputedExpression + ')' + CASE WHEN c.[Persisted] = 1 THEN ' PERSISTED' ELSE '' END
+                                                    + CASE WHEN c.[Persisted] = 1 AND ISNULL(c.[Nullable], 1) = 0 THEN ' NOT NULL' ELSE '' END
               -- Otherwise we need to build the column definition
-              ELSE REPLACE(REPLACE(UPPER(LEFT([DataType], COALESCE(NULLIF(CHARINDEX('IDENTITY', [DataType]), 0), LEN([DataType]) + 1) - 1)), 'ROWGUIDCOL', ''), 'NOT FOR REPLICATION', '') + 
+              ELSE REPLACE(REPLACE(UPPER(LEFT([DataType], COALESCE(NULLIF(CHARINDEX('IDENTITY', [DataType]), 0), LEN([DataType]) + 1) - 1)), 'ROWGUIDCOL', ''), 'NOT FOR REPLICATION', '') +
                    CASE WHEN [Collation] <> 'IGNORE' AND ISNULL(NULLIF(ic.COLLATION_NAME, @v_DatabaseCollation), '') <> [Collation] THEN ' COLLATE ' + ISNULL(NULLIF(RTRIM([Collation]), ''), @v_DatabaseCollation) ELSE '' END +
                    CASE WHEN [Sparse] = 1 THEN ' SPARSE' ELSE '' END +
                    CASE WHEN Nullable = 1 THEN ' NULL' ELSE ' NOT NULL' END +
@@ -180,7 +181,7 @@ BEGIN TRY
                                                 CASE WHEN ident.is_not_for_replication = 1 THEN ' NOT FOR REPLICATION' ELSE '' END
                                            ELSE '' END, ', ', ',')  <> REPLACE(c.DataType, ', ', ',')
         OR CASE WHEN c.Nullable = 1 THEN 'YES' ELSE 'NO' END <> ic.IS_NULLABLE
-        OR ISNULL(SchemaSmith.fn_StripParenWrapping(cc.[definition]), '') <> ISNULL(c.ComputedExpression, '')
+        OR ISNULL(SchemaSmith.fn_NormalizeExpression(cc.[definition]), '') <> ISNULL(SchemaSmith.fn_NormalizeExpression(c.ComputedExpression), '')
         OR ISNULL(cc.is_persisted, 0) <> ISNULL(c.[Persisted], 0))
         OR sc.is_sparse <> [Sparse]
         OR ISNULL(mc.masking_function, '') COLLATE DATABASE_DEFAULT <> [DataMaskFunction]
@@ -191,7 +192,8 @@ BEGIN TRY
   RAISERROR('Detect Computed Columns Impacted by Other Column Changes', 10, 100) WITH NOWAIT
   INSERT #ColumnChanges ([Schema], [TableName], [ColumnName], [ColumnScript], [SpecialColumnScript], MustDropAndRecreate, MustSwapColumn, [DropOnly])
     SELECT C.[Schema], C.[TableName], c.[ColumnName],
-           [ColumnScript] = 'AS (' + ComputedExpression + ')' + CASE WHEN c.[Persisted] = 1 THEN ' PERSISTED' ELSE '' END,
+           [ColumnScript] = 'AS (' + ComputedExpression + ')' + CASE WHEN c.[Persisted] = 1 THEN ' PERSISTED' ELSE '' END
+                                                              + CASE WHEN c.[Persisted] = 1 AND ISNULL(c.[Nullable], 1) = 0 THEN ' NOT NULL' ELSE '' END,
            [SpecialColumnScript] = '',
            MustDropAndRecreate = CAST(1 AS BIT), MustSwapColumn = CAST(0 AS BIT), [DropOnly] = CAST(0 AS BIT)
       FROM #ColumnChanges cc WITH (NOLOCK)

--- a/Schema/Scripts/SqlServer/SchemaSmith.fn_NormalizeExpression.sql
+++ b/Schema/Scripts/SqlServer/SchemaSmith.fn_NormalizeExpression.sql
@@ -1,0 +1,33 @@
+-- Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
+-- Licensed for use and modification with SchemaSmith products only.
+-- Redistribution outside of SchemaSmith product usage is prohibited.
+
+-- Normalize a SQL expression string for case- and whitespace-insensitive
+-- comparison. SQL Server stores sys.computed_columns.[definition] in a
+-- canonical form (lowercase function/keyword names, no whitespace around
+-- commas/parens, full paren wrapping). JSON-declared expressions are
+-- round-tripped verbatim and may be authored in any case + spacing style.
+-- Comparing without normalizing both sides falsely flags drift on every
+-- re-quench, kicking off a destructive drop+re-add cycle.
+--
+-- Normalization steps:
+--   (1) Strip outer paren wrapping (delegates to fn_StripParenWrapping)
+--   (2) Lowercase everything (matches the dialect SQL Server stores)
+--   (3) Strip all whitespace (space, tab, CR, LF)
+--
+-- Bracketed identifiers like [RetentionDays] survive intact through both
+-- sides (SQL Server preserves case inside brackets in stored expressions),
+-- so step (2) is safe. Step (3) is safe even for identifiers with spaces
+-- like [Order Details] because both sides normalize identically.
+
+CREATE OR ALTER FUNCTION SchemaSmith.fn_NormalizeExpression(@p_Input NVARCHAR(MAX))
+  RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+  RETURN LOWER(REPLACE(REPLACE(REPLACE(REPLACE(
+           SchemaSmith.fn_StripParenWrapping(@p_Input),
+           CHAR(9),  ''),  -- tab
+           CHAR(10), ''),  -- LF
+           CHAR(13), ''),  -- CR
+           ' ',      ''))  -- space
+END

--- a/Schema/Utility/ForgeKindler.cs
+++ b/Schema/Utility/ForgeKindler.cs
@@ -44,6 +44,7 @@ public static class ForgeKindler
         KindleOneFile(command, "SchemaSmith.fn_StripParenWrapping.sql", Platform.SqlServer);
         KindleOneFile(command, "SchemaSmith.fn_StripBracketWrapping.sql", Platform.SqlServer);
         KindleOneFile(command, "SchemaSmith.fn_SafeBracketWrap.sql", Platform.SqlServer);
+        KindleOneFile(command, "SchemaSmith.fn_NormalizeExpression.sql", Platform.SqlServer);
         KindleOneFile(command, "SchemaSmith.PrintWithNoWait.sql", Platform.SqlServer);
         KindleOneFile(command, "SchemaSmith.MissingTableAndColumnQuench.sql", Platform.SqlServer);
         KindleOneFile(command, "SchemaSmith.ModifiedTableQuench.sql", Platform.SqlServer);
@@ -181,6 +182,7 @@ public static class ForgeKindler
                 "SchemaSmith.fn_StripParenWrapping.sql",
                 "SchemaSmith.fn_StripBracketWrapping.sql",
                 "SchemaSmith.fn_SafeBracketWrap.sql",
+                "SchemaSmith.fn_NormalizeExpression.sql",
                 "SchemaSmith.PrintWithNoWait.sql",
                 "SchemaSmith.MissingTableAndColumnQuench.sql",
                 "SchemaSmith.ModifiedTableQuench.sql",

--- a/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/TableQuench_ComputedColumnIdempotencyTests.cs
+++ b/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/TableQuench_ComputedColumnIdempotencyTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
+
+using System;
+using Schema.DataAccess;
+using Schema.Domain;
+
+namespace SchemaQuench.IntegrationTests.SqlServer;
+
+// Pinning regression coverage for a computed-column idempotency bug:
+// JSON declarations of "Persisted": true, "Nullable": false on a computed
+// column (the shape used in the shipped Northwind demo's
+// recyclebin.Registry.ExpirationDate) round-trip into is_nullable=1 on the
+// live table because the DDL-emission paths build "AS (expr) PERSISTED"
+// without appending " NOT NULL" — even though SQL Server fully supports
+// "AS (expr) PERSISTED NOT NULL" on deterministic computed columns. The
+// JSON-vs-live nullability mismatch then trips drift detection on every
+// re-quench, emitting a destructive DROP COLUMN with no successful re-add
+// (the re-add hits the same gap so the cycle never converges). When the
+// column is referenced by an index, the cascade also drops that index.
+//
+// Affected DDL-emission sites (all platform Schema scripts):
+//   * ParseTableJsonIntoTempTables.sql ColumnScript               (line 60)
+//   * ModifiedTableQuench.sql #ColumnChanges.ColumnScript         (line 118)
+//   * ModifiedTableQuench.sql Add Missing Computed Columns        (line 194)
+[Category("SqlServer")]
+[Parallelizable(scope: ParallelScope.All)]
+public class TableQuench_ComputedColumnIdempotencyTests : BaseTableQuenchTests
+{
+    [Test]
+    public void TableQuench_ShouldHonorNotNullOnPersistedComputedColumn()
+    {
+        // The computed column should be created with is_nullable=0 when JSON
+        // declares Persisted:true + Nullable:false. Without the fix, the
+        // emitted DDL is "AS (expr) PERSISTED" — no NOT NULL — and SQL Server
+        // defaults computed columns to is_nullable=1.
+        var productName = Guid.NewGuid().ToString();
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        var tableName = $"NotNullPersistedComputed_{uniqueId}";
+
+        using var conn = DbConnectionFactory.ForPlatform(Platform.SqlServer).GetDbConnection(_connectionString);
+        conn.Open();
+        conn.ChangeDatabase(_mainDb);
+        using var cmd = conn.CreateCommand();
+
+        // No pre-existing table — let TableQuench create it from JSON. Mirrors
+        // the demo Northwind recyclebin.Registry shape: NOT NULL anchor, NOT
+        // NULL retention days, NOT NULL persisted computed column.
+        var json = $$"""
+{
+    "Schema": "[dbo]",
+    "Name": "[{{tableName}}]",
+    "Columns": [
+        { "Name": "[Id]",            "DataType": "INT IDENTITY(1, 1)", "Nullable": false },
+        { "Name": "[RecycledDate]",  "DataType": "DATETIME2",          "Nullable": false },
+        { "Name": "[RetentionDays]", "DataType": "INT",                "Nullable": false, "Default": "90" },
+        {
+            "Name": "[ExpirationDate]",
+            "DataType": "DATETIME2",
+            "Nullable": false,
+            "ComputedExpression": "DATEADD(DAY, [RetentionDays], [RecycledDate])",
+            "Persisted": true
+        }
+    ],
+    "Indexes": [
+        { "Name": "[PK_{{tableName}}]", "PrimaryKey": true, "Unique": true, "Clustered": true, "IndexColumns": "[Id]" }
+    ]
+}
+""";
+        cmd.CommandText = $"EXEC SchemaSmith.TableQuench @ProductName = '{productName}', @TableDefinitions = '{json.Replace("'", "''")}', @DropTablesRemovedFromProduct = 0, @DropUnknownIndexes = 0";
+        cmd.CommandTimeout = 300;
+        cmd.ExecuteNonQuery();
+
+        // Sanity: the table and computed column exist.
+        cmd.CommandText = $"SELECT CAST(CASE WHEN COLUMNPROPERTY(OBJECT_ID('[dbo].[{tableName}]'), 'ExpirationDate', 'IsComputed') = 1 THEN 1 ELSE 0 END AS BIT)";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.True, "ExpirationDate should be a computed column");
+
+        cmd.CommandText = $"SELECT [is_persisted] FROM sys.computed_columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.True, "ExpirationDate should be persisted");
+
+        // The bug: live is_nullable should be 0 because JSON declared Nullable:false,
+        // but without the fix it's 1 because the emitted DDL omitted NOT NULL.
+        cmd.CommandText = $"SELECT [is_nullable] FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.False, "ExpirationDate should be NOT NULL — JSON declared Nullable:false on a Persisted:true computed column, which SQL Server supports as 'AS (expr) PERSISTED NOT NULL'");
+
+        // Cleanup
+        cmd.CommandText = $"DROP TABLE [dbo].[{tableName}]";
+        cmd.ExecuteNonQuery();
+        conn.Close();
+    }
+
+    [Test]
+    public void TableQuench_ShouldNotDriftOnNotNullPersistedComputedColumn()
+    {
+        // Idempotency check: after the table is created, a no-op re-quench
+        // must not emit a DROP COLUMN. Without the fix, the column comes back
+        // as is_nullable=1 (Nullable mismatch with JSON Nullable:false) on
+        // every quench, triggering an endless drop-and-readd cycle that also
+        // cascades to dependent indexes.
+        var productName = Guid.NewGuid().ToString();
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        var tableName = $"NoDriftPersistedComputed_{uniqueId}";
+
+        using var conn = DbConnectionFactory.ForPlatform(Platform.SqlServer).GetDbConnection(_connectionString);
+        conn.Open();
+        conn.ChangeDatabase(_mainDb);
+        using var cmd = conn.CreateCommand();
+
+        var json = $$"""
+{
+    "Schema": "[dbo]",
+    "Name": "[{{tableName}}]",
+    "Columns": [
+        { "Name": "[Id]",            "DataType": "INT IDENTITY(1, 1)", "Nullable": false },
+        { "Name": "[RecycledDate]",  "DataType": "DATETIME2",          "Nullable": false },
+        { "Name": "[RetentionDays]", "DataType": "INT",                "Nullable": false, "Default": "90" },
+        {
+            "Name": "[ExpirationDate]",
+            "DataType": "DATETIME2",
+            "Nullable": false,
+            "ComputedExpression": "DATEADD(DAY, [RetentionDays], [RecycledDate])",
+            "Persisted": true
+        }
+    ],
+    "Indexes": [
+        { "Name": "[PK_{{tableName}}]", "PrimaryKey": true, "Unique": true, "Clustered": true, "IndexColumns": "[Id]" },
+        { "Name": "[IX_{{tableName}}_Exp]", "PrimaryKey": false, "Unique": false, "Clustered": false, "IndexColumns": "[ExpirationDate]" }
+    ]
+}
+""";
+        cmd.CommandText = $"EXEC SchemaSmith.TableQuench @ProductName = '{productName}', @TableDefinitions = '{json.Replace("'", "''")}', @DropTablesRemovedFromProduct = 0, @DropUnknownIndexes = 0";
+        cmd.CommandTimeout = 300;
+        cmd.ExecuteNonQuery();
+
+        // Capture state after first quench. column_id is a stable identity for
+        // a column — it bumps higher every time SQL Server creates a new column,
+        // even if the name is reused. A drop+re-add cycle moves the column to a
+        // larger column_id; a true no-op leaves it unchanged.
+        cmd.CommandText = $"SELECT [definition] FROM sys.computed_columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        var liveDefinitionBefore = cmd.ExecuteScalar()?.ToString();
+
+        cmd.CommandText = $"SELECT [column_id] FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        var columnIdBefore = cmd.ExecuteScalar()?.ToString();
+
+        cmd.CommandText = $"SELECT CAST(CASE WHEN INDEXPROPERTY(OBJECT_ID('[dbo].[{tableName}]'), 'IX_{tableName}_Exp', 'IndexId') IS NOT NULL THEN 1 ELSE 0 END AS BIT)";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.True, "Index on the computed column should exist after first quench");
+
+        // Re-quench the same JSON — should be a complete no-op.
+        cmd.CommandText = $"EXEC SchemaSmith.TableQuench @ProductName = '{productName}', @TableDefinitions = '{json.Replace("'", "''")}', @DropTablesRemovedFromProduct = 0, @DropUnknownIndexes = 0";
+        cmd.CommandTimeout = 300;
+        cmd.ExecuteNonQuery();
+
+        // Computed column unchanged.
+        cmd.CommandText = $"SELECT CAST(CASE WHEN COLUMNPROPERTY(OBJECT_ID('[dbo].[{tableName}]'), 'ExpirationDate', 'IsComputed') = 1 THEN 1 ELSE 0 END AS BIT)";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.True, "ExpirationDate should still be a computed column after re-quench — no drop+readd cycle");
+
+        cmd.CommandText = $"SELECT [definition] FROM sys.computed_columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        Assert.That(cmd.ExecuteScalar()?.ToString(), Is.EqualTo(liveDefinitionBefore), "ExpirationDate definition should be unchanged after a no-op re-quench");
+
+        // The load-bearing assertion: column_id must be unchanged. If TableQuench
+        // silently dropped and re-added ExpirationDate (the bug), the column_id
+        // would advance — even though the column name and definition are reused.
+        cmd.CommandText = $"SELECT [column_id] FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[{tableName}]') AND [name] = 'ExpirationDate'";
+        Assert.That(cmd.ExecuteScalar()?.ToString(), Is.EqualTo(columnIdBefore), "ExpirationDate column_id should be unchanged — a bumped column_id proves a destructive drop+re-add cycle ran");
+
+        // Dependent index survived (was NOT cascaded out by a drop+re-add).
+        cmd.CommandText = $"SELECT CAST(CASE WHEN INDEXPROPERTY(OBJECT_ID('[dbo].[{tableName}]'), 'IX_{tableName}_Exp', 'IndexId') IS NOT NULL THEN 1 ELSE 0 END AS BIT)";
+        Assert.That(cmd.ExecuteScalar() as bool?, Is.True, "Dependent index on ExpirationDate should still exist — must not be cascaded out by a false-drift drop");
+
+        // Cleanup
+        cmd.CommandText = $"DROP TABLE [dbo].[{tableName}]";
+        cmd.ExecuteNonQuery();
+        conn.Close();
+    }
+}

--- a/SchemaQuench/SchemaQuench.csproj
+++ b/SchemaQuench/SchemaQuench.csproj
@@ -26,10 +26,14 @@
 	</ItemGroup>
 
 	<!-- Bundle ICU into self-contained Linux publish output so the CLI works on minimal
-	     containers (ubuntu:24.04, fedora:latest) without system libicu. Other RIDs
-	     (Windows, macOS) get nothing extra — system ICU is reliably present and is
-	     preferred at load time. ICU version is centralized in Directory.Build.props. -->
-	<ItemGroup>
+	     containers (ubuntu:24.04, fedora:latest) without system libicu. Linux-only:
+	     setting AppLocalIcu unconditionally forces app-local lookup on every host,
+	     and Microsoft.ICU.ICU4C.Runtime only ships Linux dylibs — so on macOS/Windows
+	     the runtime hard-fails ("Failed to load app-local ICU: libicuuc...") instead
+	     of falling back to system ICU. Gate on RuntimeIdentifier so non-Linux RIDs
+	     (osx-*, win-*) and framework-dependent builds use system ICU as intended.
+	     ICU version is centralized in Directory.Build.props. -->
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(IcuVersion)" />
 		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
 	</ItemGroup>

--- a/SchemaTongs/SchemaTongs.csproj
+++ b/SchemaTongs/SchemaTongs.csproj
@@ -31,10 +31,14 @@
 	</ItemGroup>
 
 	<!-- Bundle ICU into self-contained Linux publish output so the CLI works on minimal
-	     containers (ubuntu:24.04, fedora:latest) without system libicu. Other RIDs
-	     (Windows, macOS) get nothing extra — system ICU is reliably present and is
-	     preferred at load time. ICU version is centralized in Directory.Build.props. -->
-	<ItemGroup>
+	     containers (ubuntu:24.04, fedora:latest) without system libicu. Linux-only:
+	     setting AppLocalIcu unconditionally forces app-local lookup on every host,
+	     and Microsoft.ICU.ICU4C.Runtime only ships Linux dylibs — so on macOS/Windows
+	     the runtime hard-fails ("Failed to load app-local ICU: libicuuc...") instead
+	     of falling back to system ICU. Gate on RuntimeIdentifier so non-Linux RIDs
+	     (osx-*, win-*) and framework-dependent builds use system ICU as intended.
+	     ICU version is centralized in Directory.Build.props. -->
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(IcuVersion)" />
 		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary                                                                                                                                                                         
                 
  Two unrelated SQL Server / cross-platform fixes surfaced while                                                                                                                     
  validating the SchemaSmith.com SchemaQuench/SchemaTongs/DataTongs
  walkthroughs end-to-end on a fresh clone.                                                                                                                                          
                                                                                                                                                                                   
  ### 1. macOS/Windows can't run SchemaQuench (or SchemaTongs/DataTongs) — ICU host-config gate (commit `adb3a68`)                                                                   
                                                                                                                                                                                   
  The three CLI csprojs set `System.Globalization.AppLocalIcu` and pull                                                                                                              
  in `Microsoft.ICU.ICU4C.Runtime` unconditionally — but the package                                                                                                               
  only ships Linux dylibs. Result: every macOS/Windows publish (self-                                                                                                                
  contained or framework-dependent) hard-fails at process start with                                                                                                                 
  `Failed to load app-local ICU: libicuuc.72.1.0.3.dylib` before reaching                                                                                                            
  `Main`. The csproj comment claimed macOS/Windows would fall back to                                                                                                                
  system ICU, but `AppLocalIcu` disables that fallback.                                                                                                                              
                                                                                                                                                                                     
  Repro on macOS arm64 with .NET 10:                                                                                                                                                 
  $ dotnet publish SchemaQuench/SchemaQuench.csproj -c Release -r osx-arm64 --self-contained -o /tmp/sq                                                                              
  $ /tmp/sq/SchemaQuench --help                                                                                                                                                      
  Process terminated. Failed to load app-local ICU: libicuuc.72.1.0.3.dylib
                                                                                                                                                                                     
  Fix: gate the ItemGroup on `$(RuntimeIdentifier.StartsWith('linux'))`                                                                                                              
  so non-Linux RIDs and framework-dependent builds use system ICU as                                                                                                                 
  intended. Linux self-contained publishes (Docker demo, release                                                                                                                     
  pipeline) keep AppLocalIcu and continue to bundle ICU.                                                                                                                             
                                                                                                                                                                                     
  ### 2. SQL Server computed-column idempotency on Northwind demo (commit `abab50a`)                                                                                                 
                                                                                                                                                                                     
  Two product bugs combined caused a destructive drop+re-add cycle on                                                                                                                
  every re-quench against a NOT NULL persisted computed column — first
  observed on the shipped Northwind demo's `recyclebin.Registry.ExpirationDate`:                                                                                                     
                                                                                                                                                                                     
  **Bug A** — `ParseTableJsonIntoTempTables.sql:60` and two ColumnScript                                                                                                             
  sites in `ModifiedTableQuench.sql` (lines 118, 194) build the                                                                                                                      
  column-DDL fragment for new tables and added/altered computed columns                                                                                                              
  as `AS (expr) PERSISTED` — never appending ` NOT NULL`, even when                                                                                                                  
  JSON declares `Persisted: true` + `Nullable: false`. SQL Server                                                                                                                    
  fully supports `AS (expr) PERSISTED NOT NULL` on deterministic                                                                                                                     
  computed columns under `QUOTED_IDENTIFIER ON`, but the JSON                                                                                                                        
  declaration was being silently dropped and live state always landed                                                                                                                
  at `is_nullable=1`. That mismatched JSON's `Nullable: false` and                                                                                                                   
  triggered the next bug.                                                                                                                                                            
                                                                                                                                                                                     
  **Bug B** — `ModifiedTableQuench.sql` builds the live-side type                                                                                                                    
  comparison string as `DATETIME2(7)` (concatenating `sys.types.name` +
  `DATETIME_PRECISION`). JSON-declared `"DATETIME2"` without explicit                                                                                                                
  precision arrives as `DATETIME2` and never matches. Same gap on TIME                                                                                                               
  and DATETIMEOFFSET (all three default to precision 7). On every                                                                                                                    
  re-quench the type mismatch flagged drift and emitted ALTER COLUMN —                                                                                                               
  which on a column referenced by a persisted computed column cascades                                                                                                               
  a DROP COLUMN on the dependent column. With Bug A also active, the                                                                                                                 
  re-add lost NOT NULL again and the cycle never converged.                                                                                                                          
                                                                                                                                                                                     
  Fix: canonicalize JSON-declared `DATETIME2` / `TIME` / `DATETIMEOFFSET`                                                                                                            
  to the equivalent `(7)` form at parse time, and append ` NOT NULL` to                                                                                                              
  all three computed-column DDL emission sites when JSON declares                                                                                                                    
  `Persisted: true` + `Nullable: false`.                                                                                                                                             
                                                                                                                                                                                     
  Bonus — `fn_NormalizeExpression`: a case- and whitespace-agnostic                                                                                                                  
  comparator for computed-expression strings. SQL Server stores    
  `sys.computed_columns.[definition]` lowercased + tight (e.g.                                                                                                                       
  `(dateadd(day,[X],[Y]))`); JSON expressions round-trip verbatim                                                                                                                    
  (`DATEADD(DAY, [X], [Y])`). The existing `fn_StripParenWrapping`-only                                                                                                              
  comparison flagged false drift on every quench whose JSON used spaced                                                                                                              
  authoring style. Now both sides go through `fn_NormalizeExpression`                                                                                                                
  before the `<>` compare.                                                                                                                                                           
                                                                                                                                                                                     
  ### Repro on the Northwind demo                                                                                                                                                    
                                                                   
  cd Demos/SqlServer && ./run-demo.sh                                                                                                                                                
  from host, with corrected quench-deploy.json:
                                                                                                                                                                                     
  SchemaQuench --ConfigFile:quench-deploy.json    # deploys NorthwindClone
  SchemaQuench --ConfigFile:quench-whatif.json    # WhatIf no-op                                                                                                                     
                                                                                                                                                                                     
  Pre-fix: every WhatIf wanted to drop `ExpirationDate`, drop its index                                                                                                              
  `IX_recyclebin_Registry_ExpirationDate`, and ALTER `RecycledDate`.                                                                                                                 
  Post-fix: clean no-op WhatIf, real apply leaves `recyclebin.Registry`                                                                                                              
  untouched.                                                                                                                                                                         
                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                       
                                                                   
  - [ ] CI passes                
  - [ ] `dotnet test SchemaQuench/SchemaQuench.UnitTests SchemaTongs/SchemaTongs.UnitTests DataTongs/DataTongs.UnitTests Schema/Schema.UnitTests` — 1504/1504 passing locally
  - [ ] `dotnet test SchemaQuench/SchemaQuench.IntegrationTests --filter "Category=SqlServer"` — 193/193 passing locally (includes 2 new regression tests in                         
  `TableQuench_ComputedColumnIdempotencyTests`)                                                                                                                                      
  - [ ] On a fresh macOS arm64 clone with .NET 10: `dotnet publish SchemaQuench/SchemaQuench.csproj -c Release -r osx-arm64 --self-contained -o /tmp/sq && /tmp/sq/SchemaQuench      
  --help` returns the usage banner (was: ICU FailFast)                                                                                                                               
  - [ ] On macOS arm64 clone: `cd Demos/SqlServer && ./run-demo.sh` provisions the demo cleanly; subsequent `SchemaQuench --ConfigFile:quench-deploy.json` against `NorthwindClone`
  re-runs are clean no-op WhatIfs                                                                                                                                                    
  - [ ] PostgreSQL/MySQL parallel idempotency gaps explicitly NOT addressed here — to be tackled when their walkthrough validations surface analogous fixes
                                                                                                                                                                                     
  🤖 Generated with [Claude Code](https://claude.com/claude-code) 