### PR TITLE
chore(release): v2.0.0 pre-release prep — package bumps, doc accuracy sweep, CI hygiene

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Wait for SQL Server to be ready
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             docker exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$TEST_PASSWORD" -Q "SELECT 1" > /dev/null 2>&1 && break
             sleep 2
           done
@@ -184,9 +184,10 @@ jobs:
       - name: Increase PostgreSQL max connections
         run: |
           PGPASSWORD="$TEST_PASSWORD" psql -h 127.0.0.1 -U "$TEST_USER" -d TestMain -c "ALTER SYSTEM SET max_connections = 500;"
+          # shellcheck disable=SC2046  # docker restart accepts multiple IDs; word splitting is intentional
           docker restart $(docker ps -q --filter "ancestor=postgres:latest")
           sleep 5
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             PGPASSWORD="$TEST_PASSWORD" psql -h 127.0.0.1 -U "$TEST_USER" -d TestMain -c "SELECT 1" > /dev/null 2>&1 && break
             sleep 2
           done

--- a/.github/workflows/copyright-header-check.yml
+++ b/.github/workflows/copyright-header-check.yml
@@ -1,0 +1,68 @@
+name: copyright-header-check
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  check-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v4
+
+      - name: Check copyright headers
+        run: |
+          CS_HEADER="// Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0."
+          SQL_HEADER="-- Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0."
+          FAILED=0
+
+          # Strip a leading UTF-8 BOM (EF BB BF) before comparing the first line —
+          # historically some Schema/Scripts/*.sql files were saved BOM'd for SSMS
+          # round-trip safety, and the BOM is harmless to runtime behavior on
+          # SQL Server / PostgreSQL / MySQL clients we target.
+          read_first_line() {
+            head -1 "$1" | sed -e $'1s/^\xEF\xBB\xBF//' | tr -d '\r'
+          }
+
+          # Check .cs files (exclude bin, obj, Demos, demo, TestProducts, MigrationScripts)
+          while IFS= read -r file; do
+            first_line=$(read_first_line "$file")
+            if [ "$first_line" != "$CS_HEADER" ]; then
+              echo "MISSING: $file"
+              FAILED=1
+            fi
+          done < <(find . -name '*.cs' \
+            -not -path '*/bin/*' \
+            -not -path '*/obj/*' \
+            -not -path '*/Demos/*' \
+            -not -path './demo/*' \
+            -not -path '*/TestProducts/*' \
+            -not -path '*/MigrationScripts/*')
+
+          # Check .sql files under Schema/Scripts/
+          while IFS= read -r file; do
+            first_line=$(read_first_line "$file")
+            if [ "$first_line" != "$SQL_HEADER" ]; then
+              echo "MISSING: $file"
+              FAILED=1
+            fi
+          done < <(find ./Schema/Scripts -name '*.sql' 2>/dev/null)
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "ERROR: The above files are missing the required copyright header."
+            echo ""
+            echo "Expected first line for .cs files:"
+            echo "  $CS_HEADER"
+            echo ""
+            echo "Expected first line for .sql files in Schema/Scripts/:"
+            echo "  $SQL_HEADER"
+            exit 1
+          fi
+
+          echo "All files have correct copyright headers."

--- a/Demos/README.md
+++ b/Demos/README.md
@@ -6,11 +6,10 @@ Demo database schema packages for SQL Server, PostgreSQL, and MySQL, deployed by
 
 | Product | SQL Server | PostgreSQL | MySQL |
 |---------|:---:|:---:|:---:|
-| ValidProduct | Done | Done | Done |
 | AdventureWorks | Done | Done | Done |
-| Sakila | Done | Done | Done |
-| Northwind | Done | Done | Done |
 | Chinook | Done | Done | Done |
+| Northwind | Done | Done | Done |
+| Sakila | Done | Done | Done |
 
 ## Quick Start
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,12 +46,13 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
 
     <!-- Test infrastructure -->
+    <!-- coverlet.collector held at 8.0.1 — 10.0.0 is a two-major bump; deferred to post-v2 maintenance -->
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <!-- NSubstitute 5.3.0 — latest stable; 6.0.0 is RC only -->
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/Schema/DataAccess/SqlServerConnectionFactory.cs
+++ b/Schema/DataAccess/SqlServerConnectionFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) SchemaSmith, LLC. All rights reserved.
+// Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
 using System.Data;
 using Microsoft.Data.SqlClient;

--- a/Schema/Schema.UnitTests/Utility/TokenHelperTests.cs
+++ b/Schema/Schema.UnitTests/Utility/TokenHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) SchemaSmith, LLC. All rights reserved.
+// Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
 using System;
 using System.Collections.Generic;

--- a/docs/FEATURE_LIST.md
+++ b/docs/FEATURE_LIST.md
@@ -234,7 +234,7 @@ The extraction engine. Reads a live database into a versioned schema package usi
 | `FolderMapping` rename (per object type) | ✓ | ✓ | ✓ | |
 | `CREATE OR ALTER` formatting | ✓ | ✓ | ✓ | |
 | Extensions / custom-property preservation across re-extraction | ✓ | ✓ | ✓ | |
-| Auto-exclusion of system schemas | ✓ | ✓ | ✓ | `dbo`/`sys`/`pg_*`/`mysql`/`information_schema` etc. |
+| Auto-exclusion of system / SchemaSmith objects | ✓ | ✓ | ✓ | Objects under `sys` / `INFORMATION_SCHEMA` (SQL Server), `pg_*` / `information_schema` (PG), `mysql` / `information_schema` / `performance_schema` / `sys` (MySQL), and the `SchemaSmith` infrastructure schema. `dbo` (SQL Server) and `public` (PG) are extracted normally — they're user schemas, not system. |
 | Encrypted object skip + warn | ✓ | n/a | n/a | NULL `sys.sql_modules.definition` |
 | Replication-artifact exclusion | ✓ | n/a | n/a | `MSPeer_`, `MSPub_` |
 | Dynamic function-dependency drop / recreate scripting | ✓ | ✓ | ✓ | `ScriptDynamicDependencyRemovalForFunctions` |

--- a/docs/end-user/README.md
+++ b/docs/end-user/README.md
@@ -84,7 +84,9 @@ Already know what you're looking for? Jump straight to the details.
 
 Nothing beats working with real data. The repository includes demo products you can extract, deploy, and explore against a local database container.
 
-- **Northwind** — the classic getting-started schema
 - **AdventureWorks** — real-world complexity
+- **Chinook** — the classic media-store schema
+- **Northwind** — the canonical getting-started schema
+- **Sakila** — the DVD rental store schema
 
-All demos were extracted and deployed end-to-end with SchemaSmith tools.
+All four demos are deployed on all three platforms (SQL Server, PostgreSQL, MySQL) by the per-platform `docker-compose.yml` files under `Demos/`. Each one was extracted and deployed end-to-end with SchemaSmith tools.

--- a/docs/end-user/guide/02-quick-start.md
+++ b/docs/end-user/guide/02-quick-start.md
@@ -2,7 +2,7 @@
 
 In the next 15 minutes, you'll extract a real database into version-controlled files, deploy them to a fresh empty database, make a schema change, and watch SchemaSmith compute the exact DDL needed to bring the target in line. By the end, you'll have completed the full SchemaSmith cycle -- and you'll understand why teams stop writing migration scripts once they've seen this.
 
-This walkthrough uses **SQL Server** as the primary example, but the exact same workflow works against **PostgreSQL** and **MySQL**. Each platform has a demo product (Northwind and Chinook for SQL Server and MySQL, Northwind and Sakila for PostgreSQL) -- pick whichever engine your team runs.
+This walkthrough uses **SQL Server** as the primary example, but the exact same workflow works against **PostgreSQL** and **MySQL**. Every platform ships the same four demo products (AdventureWorks, Chinook, Northwind, Sakila) -- pick whichever engine your team runs.
 
 ## Prerequisites
 
@@ -49,7 +49,7 @@ The launcher runs `build-schemaquench.sh` to compile the SchemaQuench binary (re
 | User     | `TestUser` |
 | Password | _(see `Demos/SqlServer/.env`)_ |
 
-> **PostgreSQL or MySQL?** Swap the platform folder: `Demos/PostgreSQL` (port `5432`) or `Demos/MySQL` (port `3306`). Each platform has its own `run-demo.sh` / `run-demo.cmd` launcher, `.env` credentials file, and demo databases (Northwind, Chinook, AdventureWorks, and Sakila for PostgreSQL; Northwind and Chinook for SQL Server and MySQL). On MySQL the demo databases are stored in lowercase (`northwind`, `chinook`) because Linux MySQL containers default to `lower_case_table_names=1`; use the lowercase form in your `Database` / `NorthwindDb` config values when the platform is MySQL.
+> **PostgreSQL or MySQL?** Swap the platform folder: `Demos/PostgreSQL` (port `5432`) or `Demos/MySQL` (port `3306`). Each platform has its own `run-demo.sh` / `run-demo.cmd` launcher, `.env` credentials file, and the same four demo databases (AdventureWorks, Chinook, Northwind, Sakila). On MySQL the demo databases are stored in lowercase (`adventureworks`, `chinook`, `northwind`, `sakila`) because Linux MySQL containers default to `lower_case_table_names=1`; use the lowercase form in your `Database` / `NorthwindDb` config values when the platform is MySQL.
 
 ## Step 2: Cast with SchemaTongs
 

--- a/docs/end-user/guide/09-power-workflows.md
+++ b/docs/end-user/guide/09-power-workflows.md
@@ -193,7 +193,7 @@ Then declare per-folder routing on your product-level folders:
 
 ```json
 {
-  "Folders": [
+  "ScriptFolders": [
     { "FolderPath": "Before Product",       "QuenchSlot": "Before", "ServerToQuench": "Both" },
     { "FolderPath": "Linked Server Setup",  "QuenchSlot": "Before", "ServerToQuench": "Primary" },
     { "FolderPath": "Local Cache Build",    "QuenchSlot": "After",  "ServerToQuench": "Secondary" }

--- a/docs/end-user/guide/10-edge-cases.md
+++ b/docs/end-user/guide/10-edge-cases.md
@@ -134,7 +134,7 @@ When `RunScriptsTwice` is enabled, SchemaQuench runs the entire set of object sc
 {
   "Name": "MyProduct",
   "Platform": "SqlServer",
-  "MinimumVersion": "Sql2016",
+  "MinimumVersion": "2017",
   "ValidationScript": "SELECT CAST(1 AS BIT)"
 }
 ```

--- a/docs/end-user/guide/installation.md
+++ b/docs/end-user/guide/installation.md
@@ -33,7 +33,7 @@ wget https://github.com/Schema-Smith/SchemaSmith/releases/download/v2.0.0/schema
 sudo dpkg -i schemasmith_2.0.0_amd64.deb
 ```
 
-Binaries land under `/usr/lib/schemasmith/` with symlinks in `/usr/bin/` so `schemaquench`, `schematongs`, and `datatongs` are immediately on PATH. Zero declared package dependencies -- the binaries are fully self-contained and run with `InvariantGlobalization` enabled, so they work on minimal containers and hardened distros that ship without `libicu`.
+Binaries land under `/usr/lib/schemasmith/` with symlinks in `/usr/bin/` so `schemaquench`, `schematongs`, and `datatongs` are immediately on PATH. Zero declared package dependencies -- the binaries are fully self-contained and bundle their own ICU runtime alongside the executables, so they work on minimal containers and hardened distros that ship without `libicu`.
 
 Both `amd64` and `arm64` builds are published with every release. Use `schemasmith_<version>_arm64.deb` on ARM hosts.
 

--- a/docs/end-user/reference/configuration.md
+++ b/docs/end-user/reference/configuration.md
@@ -6,7 +6,7 @@ Applies to: SchemaQuench, SchemaTongs, DataTongs — SQL Server, PostgreSQL, and
 
 Every SchemaSmith CLI tool shares the same configuration spine -- one consistent system for settings files, environment variables, and command-line switches. Learn it once and it works the same way whether you're casting schemas, quenching databases, or extracting data, and whether your target is SQL Server, PostgreSQL, or MySQL. Tool-specific settings live on each tool's own reference page; this page covers the shared foundation.
 
-The **platform** each operation runs against is not a CLI switch or an environment variable -- it's a property of the schema package itself. `Product.json` declares `Platform` (`SqlServer`, `PostgreSql`, or `MySql`), and the tools adapt their behavior accordingly. One tool, three engines, same muscle memory.
+The **platform** each operation runs against is not a CLI switch or an environment variable -- it's a property of the schema package itself. `Product.json` declares `Platform` (`SqlServer`, `PostgreSQL`, or `MySQL`), and the tools adapt their behavior accordingly. One tool, three engines, same muscle memory.
 
 ---
 
@@ -40,7 +40,7 @@ Every SchemaSmith CLI tool recognizes these switches. They're processed before a
 
 | Switch | Aliases | Description |
 |---|---|---|
-| `--version` | `-v`, `--ver` | Print the tool name, edition, and version number, then exit. |
+| `--version` | `-v`, `--ver` | Print the tool name and version number, then exit. |
 | `--help` | `-h`, `-?` | Print the available command-line switches, then exit. |
 | `--ConfigFile:<path>` | | Path to the settings file. Overrides the default `<ToolName>.settings.json`. |
 | `--LogPath:<path>` | | Directory for log files and backup subdirectories. Defaults to the tool's executable directory. |
@@ -294,7 +294,7 @@ DataTongs --LogPath:D:\BuildLogs
 
 ### Startup configuration dump
 
-Immediately after loading configuration, every tool logs its complete active configuration to the progress log. This includes the tool name, edition, and version number, followed by every configuration key and its value (with passwords masked). This makes it straightforward to verify what settings were in effect for any given run.
+Immediately after loading configuration, every tool logs its complete active configuration to the progress log. This includes the tool name and version number, followed by every configuration key and its value (with passwords masked). This makes it straightforward to verify what settings were in effect for any given run.
 
 ### Log backup rotation
 

--- a/docs/end-user/reference/datatongs.md
+++ b/docs/end-user/reference/datatongs.md
@@ -2,7 +2,7 @@
 
 Lookup tables, configuration rows, seed data -- every database has reference data that needs to travel with the schema. DataTongs grips that data from a live database and produces self-contained synchronization scripts that bring it into any target. Point it at a source, list the tables you care about, and it produces one SQL file per table -- ready to drop into a schema package's `Table Data` folder or run directly against any compatible instance.
 
-DataTongs supports **SQL Server**, **PostgreSQL**, and **MySQL**. The script syntax adapts per platform: SQL Server and PostgreSQL use `MERGE`, MySQL uses `INSERT ... ON DUPLICATE KEY UPDATE` (or `REPLACE` where appropriate). The configuration shape and the workflow are identical across all three.
+DataTongs supports **SQL Server**, **PostgreSQL**, and **MySQL**. The script syntax adapts per platform: SQL Server and PostgreSQL use `MERGE`, MySQL uses `INSERT ... ON DUPLICATE KEY UPDATE` (paired with a conditional `DELETE WHERE NOT EXISTS` step when full delete sync is enabled). The configuration shape and the workflow are identical across all three.
 
 ---
 
@@ -103,7 +103,7 @@ The typical placement inside a schema package is `ScriptPath` pointing at `Templ
 | `ShouldCast:OutputContentFiles` | bool | `false` | Write raw data to sibling `.tabledata` content files. Automatically enabled when `ConfigureDataDelivery` is on. |
 | `ShouldCast:DisableTriggers` | bool | `false` | Wraps the generated script with platform-appropriate trigger disable/enable. |
 | `ShouldCast:MergeUpdate` | bool | `true` | Includes the update branch (matched rows whose data has changed). |
-| `ShouldCast:MergeDelete` | bool | `true` | Includes the delete branch (target rows missing from the source). MySQL note: `MergeDelete` is not supported via `INSERT ... ON DUPLICATE KEY UPDATE`; use `REPLACE` semantics or hand-author migration scripts when full delete sync is required on MySQL. |
+| `ShouldCast:MergeDelete` | bool | `true` | Includes the delete branch (target rows missing from the source). On all three platforms: SQL Server / PostgreSQL emit `WHEN NOT MATCHED BY SOURCE THEN DELETE` inside the `MERGE`; MySQL emits an `INSERT ... ON DUPLICATE KEY UPDATE` followed by a separate `DELETE WHERE NOT EXISTS` step (because MySQL has no `MERGE`). |
 | `ShouldCast:MergeType` | string | `Insert/Update` | Default `DataDelivery:MergeType` for tables that don't set it explicitly. Values: `None`, `Insert`, `Insert/Update`, `Insert/Update/Delete`. Used when writing `DataDelivery` blocks via `--ConfigureDataDelivery`. |
 | `ShouldCast:ConfigureDataDelivery` | bool | `false` | After extraction, write a `DataDelivery` block into each matching table's JSON file. See [--ConfigureDataDelivery](#--configuredatadelivery). |
 | `ShouldCast:TokenizeScripts` | bool | `false` | **SQL Server only.** Replaces the source database name with script tokens in the generated merge scripts, matching SchemaTongs' tokenization behavior. |
@@ -282,9 +282,14 @@ When enabled, DataTongs wraps each generated script with platform-appropriate tr
 
 When enabled, the script updates existing rows whose data has changed. When disabled, the script only inserts new rows and (on MERGE platforms, if `MergeDelete` is on) deletes missing rows -- existing rows are left untouched regardless of whether their data differs.
 
-### MergeDelete (SQL Server / PostgreSQL)
+### MergeDelete
 
 When enabled, the script deletes rows from the target that don't exist in the source data. When a `Filter` is configured, the delete clause respects the filter so that rows outside the filter are never removed. When disabled, the script only inserts and updates -- no rows are ever deleted from the target.
+
+**Per-platform implementation:**
+
+- **SQL Server / PostgreSQL:** The delete is a `WHEN NOT MATCHED BY SOURCE THEN DELETE` clause inside the same `MERGE` statement.
+- **MySQL:** Because MySQL has no `MERGE`, the generated script is two statements -- an `INSERT ... ON DUPLICATE KEY UPDATE` for the upsert plus a separate `DELETE WHERE NOT EXISTS` that removes target rows missing from the source. (The retired `REPLACE INTO` idiom isn't used: it deletes and re-inserts every matched row, which breaks `ON DELETE RESTRICT` foreign keys.)
 
 ### Delivery scenarios
 

--- a/docs/end-user/reference/schema-packages.md
+++ b/docs/end-user/reference/schema-packages.md
@@ -24,7 +24,10 @@ The `Product.json` file sits at the root of the schema package and is the top-le
 | `DropUnknownIndexes` | bool | `false` | No | When `true`, the table quench drops indexes on managed tables that aren't defined in the table JSON. |
 | `MinimumVersion` | string | | No | Minimum target server version. Currently metadata only -- displayed in tooling and available for future version-adaptive features. Use `ValidationScript` for runtime version enforcement. |
 | `CheckConstraintStyle` | string | `"ColumnLevel"` | No | Controls how SchemaTongs writes check constraints during extraction: `"ColumnLevel"` (inline `CheckExpression` on the column) or `"TableLevel"` (named constraints in the `CheckConstraints` array). |
-| `Folders` | array | `[]` | No | Optional product-level folder definitions. Used to add custom folder paths or assign secondary-server filtering. See [Custom Script Folders](#custom-script-folders). |
+| `ScriptFolders` | array | `[]` | No | Optional product-level folder definitions. Used to add custom folder paths or assign secondary-server filtering. See [Custom Script Folders](#custom-script-folders). |
+| `BranchNameFile` | string | `"{{repo_path}}/.git/HEAD"` | No | Path to the file SchemaSmith reads to derive the `{{BranchName}}` automatic token. Default points at Git's `HEAD`. Use any VCS that exposes the current branch as a single-line file (Mercurial's `.hg/branch`, Subversion working-copy markers, etc.); the only requirement is that the file exists and contains the branch identifier somewhere on its first line. |
+| `BeforeBranchNameMask` | string | `"ref: refs/heads/"` | No | Prefix to strip from the line read out of `BranchNameFile`. Default matches Git's `ref: refs/heads/<branch>` format. Set to `""` for VCSs whose branch file already contains the bare branch name. |
+| `AfterBranchNameMask` | string | `""` | No | Suffix to strip after the prefix is removed. Default empty. Set when your VCS appends extra text after the branch name. |
 | `Extensions` | any | `null` | No | Reserved. `Product.json` does not currently use `Extensions` for custom properties. |
 
 ### Settings intent
@@ -177,7 +180,7 @@ Custom script folders are how you make the schema package fit *your* deployment 
 
 ### Custom product-level folders
 
-`Product.json` can also declare custom folders via its `Folders` array. The shape is similar but uses `ProductQuenchSlot` (`Before` or `After`) and supports a `ServerToQuench` setting that controls whether the folder runs on the primary, secondaries, or both. See [Secondary Servers](#secondary-servers) below.
+`Product.json` can also declare custom folders via its `ScriptFolders` array (the property name is the same as `Template.json`'s). The shape is similar but uses `ProductQuenchSlot` (`Before` or `After`) and supports a `ServerToQuench` setting that controls whether the folder runs on the primary, secondaries, or both. See [Secondary Servers](#secondary-servers) below.
 
 ---
 
@@ -295,7 +298,7 @@ Then declare `ServerToQuench` on your product-level folders:
 {
   "Name": "MyProduct",
   "Platform": "SqlServer",
-  "Folders": [
+  "ScriptFolders": [
     { "FolderPath": "Before Product",        "QuenchSlot": "Before", "ServerToQuench": "Both" },
     { "FolderPath": "Linked Server Setup",   "QuenchSlot": "Before", "ServerToQuench": "Primary" },
     { "FolderPath": "Local Cache Build",     "QuenchSlot": "After",  "ServerToQuench": "Secondary" }
@@ -375,7 +378,7 @@ Each platform's table definition extends the shared properties with engine-speci
 |---|---|---|---|
 | `Schema` | string | `"dbo"` | Database schema. Use bracket notation in extracted files (e.g., `"[Production]"`). |
 | `CompressionType` | string | `"NONE"` | Data compression: `"NONE"`, `"ROW"`, `"PAGE"`. |
-| `IsTemporal` | bool | `false` | Marks the table as a system-versioned temporal table. |
+| `IsTemporal` | bool | `false` | When `true`, SchemaQuench manages the table as system-versioned temporal: emits `ALTER TABLE ... SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = <Schema>.<Name>_Hist))` and protects the period columns (`ValidFrom` / `ValidTo`) from drop detection. When toggled back to `false`, SchemaQuench emits `SET (SYSTEM_VERSIONING = OFF)`. The history table itself (`<Name>_Hist` in the same schema) is not auto-created -- declare it as a sibling table JSON in your package or rely on a Before script that creates it before the `IsTemporal=true` table is quenched. |
 | `XmlIndexes` | array | `[]` | XML index definitions. See [XML Indexes (SQL Server)](#xml-indexes-sql-server). |
 | `Statistics` | array | `[]` | Custom statistics definitions. See [Statistics (SQL Server)](#statistics-sql-server). |
 | `FullTextIndex` | object | `null` | Single full-text index on the table. See [Full-Text Index (SQL Server)](#full-text-index-sql-server). |

--- a/docs/end-user/reference/schemaquench.md
+++ b/docs/end-user/reference/schemaquench.md
@@ -58,9 +58,11 @@ SchemaQuench reads configuration from `SchemaQuench.settings.json` (or the file 
 | `KindleTheForge` | bool | `true` | Deploy SchemaSmith helper procedures and the migration tracking table to each target database before quenching. |
 | `UpdateTables` | bool | `true` | Apply table structure changes (columns, indexes, constraints, foreign keys) from the schema package. |
 | `DropTablesRemovedFromProduct` | bool | `true` | Drop tables that exist in the database but aren't defined in the schema package. |
+| `DeliverData` | bool | `true` | Run the per-table `DataDelivery` step and the `TableData`-slot scripts. Set to `false` to ship a structure-only deployment that leaves reference data untouched -- pairs naturally with `UpdateTables: true` for "deploy schema, skip data" pipelines. |
 | `RunScriptsTwice` | bool | `false` | Run object scripts twice to verify idempotency. A CI/testing tool. |
 | `TrackRunOnceMigrations` | bool | `true` | Track run-once migration scripts. When `false`, all scripts run on every deployment. |
 | `PruneObsoleteMigrationTracking` | bool | `true` | Remove tracking entries for scripts no longer in the package. |
+| `CheckpointDirectory` | string | `""` | Directory for checkpoint files used by `--ResumeQuench`. When blank, defaults to a per-platform temp location. See [Checkpoint and Resume](#checkpoint-and-resume). |
 | `MaxThreads` | int | `10` | Number of parallel database operations. Range 1--20. |
 | `VerboseLogging` | bool | `false` | Include `PRINT` / `RAISE NOTICE` / equivalent informational output from user scripts in logs. |
 | `ScriptTokens` | object | `{}` | Config-level overrides for product script tokens. |
@@ -84,9 +86,11 @@ SchemaQuench reads configuration from `SchemaQuench.settings.json` (or the file 
   "KindleTheForge": true,
   "UpdateTables": true,
   "DropTablesRemovedFromProduct": true,
+  "DeliverData": true,
   "RunScriptsTwice": false,
   "TrackRunOnceMigrations": true,
   "PruneObsoleteMigrationTracking": true,
+  "CheckpointDirectory": "",
   "MaxThreads": 10,
   "VerboseLogging": false,
   "ScriptTokens": {}
@@ -283,7 +287,7 @@ The four flags are a *profile*, not a menu -- mixing partial-package intent with
 ### Patterns that pair well with data fixes
 
 - **[Checkpoint and resume](#checkpoint-and-resume)** -- When a datafix touches a large dataset and may need to be retried after a connection drop or server restart, enable resume so the fix picks up where it left off instead of re-running completed work.
-- **Slot choice** -- Even in a partial package, the migration script's slot still determines *when* in the deployment sequence it runs relative to the (skipped) table-quench phase. `BeforeTables`, `AfterTablesScripts`, and `After` are the usual homes for data fixes. The slot is a namespacing and timing signal; the fact that a data fix typically has no tables to run *between* doesn't change the ordering contract.
+- **Slot choice** -- Even in a partial package, the migration script's slot still determines *when* in the deployment sequence it runs relative to the (skipped) table-quench phase. The four sequential, tracked migration slots -- `Before`, `BetweenTablesAndKeys`, `AfterTablesScripts`, and `After` -- are the usual homes for data fixes. The slot is a namespacing and timing signal; the fact that a data fix typically has no tables to run *between* doesn't change the ordering contract.
 
 A data fix should not carry `DataDelivery` blocks or table JSON. If your fix is "re-seed this reference table," the right shape is usually a migration script that does the seeding imperatively (or calls a stored procedure that does), not a DataDelivery block in what would then stop being a partial package.
 
@@ -413,7 +417,9 @@ You can also pass the full schema tokens (`{{TableSchema}}`, `{{IndexedViewSchem
 | WhatIf | Default: off | Default: off | Default: off |
 | DropUnknownIndexes | Default: off | -- | -- |
 | DropTablesRemovedFromProduct | Default: on | -- | -- |
-| UpdateFillFactor | Default: on | Default: off | Default: on |
+| UpdateFillFactor | SQL Server / PG only -- Default: on | Default: off | Default: on |
+
+> **MySQL note:** `SchemaSmith_TableQuench` on MySQL has no `UpdateFillFactor` parameter -- fill factor is a SQL Server / PostgreSQL concept and the MySQL procedure simply omits it. The MySQL example above (six positional args) reflects the actual signature.
 
 **When to use direct calls:** When a migration script needs a table or view to exist before it can run -- for example, bootstrapping an audit table in a Before Script before inserting migration tracking data, or ensuring a materialized view is deployed before populating dependent tables.
 
@@ -663,7 +669,7 @@ SchemaQuench tracks two kinds of progress:
 | `IndexedViewQuench` | SQL Server indexed view deployment. |
 | `VersionStamp` | Version stamp script. |
 
-In addition, each template slot (`Before`, `Objects`, `AfterTablesObjects`, `BetweenTablesAndKeys`, `AfterTable`, `TableData`, `After`) records the exact scripts that ran, so resumed runs skip each individual script that already succeeded.
+In addition, each template slot (`Before`, `Objects`, `BetweenTablesAndKeys`, `AfterTablesScripts`, `AfterTablesObjects`, `TableData`, `After`) records the exact scripts that ran, so resumed runs skip each individual script that already succeeded.
 
 ### Automatic cleanup after success
 

--- a/docs/end-user/reference/schematongs.md
+++ b/docs/end-user/reference/schematongs.md
@@ -43,10 +43,14 @@ SchemaTongs connects to the source database, reads every enabled object type, an
 
 ### Schema-only mode
 
-If you just need to regenerate the `.json-schemas/*.schema` validation files for an existing product -- without connecting to a database -- use the `--WriteSchemasOnly` switch:
+If you just need to regenerate the `.json-schemas/*.schema` validation files for an existing product -- without connecting to a database -- use the `--WriteSchemasOnly` switch. The product path comes from your `SchemaTongs.settings.json` (or an environment variable override), not from the command line:
 
 ```bash
-SchemaTongs --WriteSchemasOnly --Product:Path:./my-product
+# Run from the directory that contains SchemaTongs.settings.json with Product:Path already set
+SchemaTongs --WriteSchemasOnly
+
+# Or set the path inline via environment variable (note the double underscore for the nested key)
+SmithySettings_Product__Path=./my-product SchemaTongs --WriteSchemasOnly
 ```
 
 This reads the `Platform` from `Product.json`, regenerates the schema files on the fly from the current engine's C# domain types, and exits. No database connection, no extraction. Useful when you've updated SchemaSmith and want CI validation to match the new engine without re-extracting.
@@ -450,8 +454,10 @@ When SchemaTongs encounters an encrypted object on SQL Server (a function, view,
 SchemaTongs automatically excludes the platform's system schemas and internal infrastructure:
 
 - **System objects** -- Anything flagged as system-shipped by the source engine.
-- **Built-in schemas** -- `dbo`, `guest`, `INFORMATION_SCHEMA`, `sys` (SQL Server); `pg_*`, `information_schema` (PostgreSQL); `mysql`, `information_schema`, `performance_schema`, `sys` (MySQL).
+- **System schemas** -- `sys` and `INFORMATION_SCHEMA` (SQL Server); `pg_catalog`, `information_schema`, `pg_toast`, and the per-session `pg_temp_*` / `pg_toast_temp_*` schemas (PostgreSQL). On MySQL, SchemaTongs is single-schema-scoped: it extracts only the schema named in `Source:Database`, so the system schemas (`mysql`, `information_schema`, `performance_schema`, `sys`) are simply outside scope unless you point at one explicitly.
+- **User schemas are NOT excluded.** SQL Server's `dbo` and `guest`, and PostgreSQL's `public`, are user schemas. Their tables, views, procedures, functions, triggers, and types are all extracted normally. The shipped Northwind demo lives under `dbo` and round-trips end to end.
 - **SchemaSmith infrastructure** -- All objects in the `SchemaSmith` schema (the helper procedures SchemaTongs and SchemaQuench deploy).
+- **Schema-creation script gaps (SQL Server)** -- The pass that emits `Schemas/*.sql` scripts additionally skips system-shipped schemas (`schema_id <= 4`, which covers `dbo`, `guest`, `INFORMATION_SCHEMA`, `sys`) and database-role schemas (names matching `db[_]%`). Object extraction under those schemas is not affected -- the gap is only in the standalone `CREATE SCHEMA` scripts.
 - **Replication artifacts** (SQL Server) -- Tables prefixed with `MSPeer_` or `MSPub_`.
 - **Legacy system tables** (SQL Server) -- `dtproperties` and `sysdiagrams`.
 


### PR DESCRIPTION
## Summary

Bundled pre-release work for the v2.0.0 cut. Four work areas, one PR.

### NuGet test infrastructure
- `Microsoft.NET.Test.Sdk` 18.4.0 → 18.5.1, `NUnit` 4.5.1 → 4.6.0, `NUnit.Analyzers` 4.12.0 → 4.13.0 (all safe — patch / minor)
- `coverlet.collector` held at 8.0.1 with deferral comment; the 10.0.0 bump crosses two majors and was deferred to a post-v2 maintenance item rather than landing eight days before the MSSQLTips ad drop.

### Copyright-header CI restoration
The `copyright-header-check.yml` workflow was deleted in the v2 foundation cut and never re-added when `dev/v2` merged to `main`, so header validation has been silently unenforced on `main` since 2026-05-03.

- Restore the workflow with `Demos/` added to exclusions (renamed from `demo/` in v2) and BOM-tolerant first-line comparison (existing `Schema/Scripts/*.sql` files have UTF-8 BOMs that are harmless to runtime behavior but broke exact-match).
- Fix two `.cs` files (`SqlServerConnectionFactory.cs`, `TokenHelperTests.cs`) that still carried the pre-SSCL-v2.0 header text. Audit confirms all 380 .cs/.sql files now pass.

### Documentation accuracy sweep — 28 findings across 11 files
Cross-checked `docs/end-user/` against the actual code per a doc-vs-code reverse audit.

**CRITICAL (user-breaking):** README + Quick Start demo product lists corrected to all four products on all three platforms; `BeforeTables` slot is fictional (replaced with the four real sequential-tracked migration slots); `dbo`/`guest` are NOT auto-excluded from extraction (Excluded Objects section reframed with actual filter behavior + explicit "user schemas ARE extracted" callout); `--Product:Path:./my-product` CLI example doesn't work (CLI args don't flow into `IConfigurationRoot`); MySQL `MergeDelete` IS supported via ODKU + `DELETE WHERE NOT EXISTS` (three claim sites + section header corrected); `Folders` → `ScriptFolders` everywhere (AG secondary-server routing examples would have silently failed because of the wrong property name); `FEATURE_LIST.md` `dbo` claim corrected.

**MAJOR:** TableQuench parameter table — `UpdateFillFactor` is SQL Server / PG only; MySQL TableQuench has no such parameter.

**MINOR:** `--version` "edition" claim removed (consolidated to single edition in v2); `PostgreSql`/`MySql` capitalization → canonical `PostgreSQL`/`MySQL`; `MinimumVersion: "Sql2016"` example unparseable → changed to `"2017"`; checkpoint slot list switched to template-slot names readers know; `installation.md` `InvariantGlobalization` claim is stale (the 2026-04-29 fix replaced it with the app-local ICU bundle pattern).

**NOTE:** Documented `DeliverData` and `CheckpointDirectory` (omitted from Behavior Settings table); documented `BranchNameFile` / `BeforeBranchNameMask` / `AfterBranchNameMask` (Product properties driving the `{{BranchName}}` auto-token); reframed `IsTemporal` from "marker only" to actual SYSTEM_VERSIONING behavior with history-table convention; removed `ValidProduct` row from `Demos/README.md` table (it's a tutorial scaffold, not a deployed demo).

### CI workflow hygiene
`continuous-integration.yml` shellcheck warnings cleared — unused loop counter `i` → `_`, and SC2046 false positive on `docker restart \$(docker ps -q ...)` disabled with a rationale comment (multiple-ID handling is intentional word splitting).

## Test plan

- [x] `dotnet build SchemaSmith.sln -c Release` — 0 warnings, 0 errors
- [x] 1504/1504 unit tests pass (Schema, SchemaQuench, SchemaTongs, DataTongs)
- [x] Coverage — lowest 89%, average 90% (target >85%)
- [x] \`shellcheck --shell=sh packaging/install/install.sh\` clean
- [x] \`actionlint\` clean across all five workflows
- [x] BOM-tolerant header audit — 322 .cs + 58 .sql files pass
- [x] \`dotnet publish\` win-x64 self-contained for all three CLIs — each binary starts and reports \`Version: 2.0.0.0\`
- [ ] CI matrix (SQL Server, PostgreSQL, MySQL integration tests + copyright-header-check) green on this PR
- [ ] Post-merge CI green on \`main\` before triggering \`release.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)