### PR TITLE
fix(schema): TaskQueueManager no longer wedges on unhandled exception

### DIFF
--- a/Schema/Schema.UnitTests/Utility/TaskQueueManagerTests.cs
+++ b/Schema/Schema.UnitTests/Utility/TaskQueueManagerTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Schema.Utility;
 
 namespace Schema.UnitTests.Utility;
@@ -183,6 +184,59 @@ public class TaskQueueManagerTests
         Assert.That(processed, Has.Count.EqualTo(2));
         Assert.That(processed, Does.Contain(date1));
         Assert.That(processed, Does.Contain(date2));
+    }
+
+    [Test]
+    public void WaitForAll_DoesNotHangWhenWorkThrows()
+    {
+        using var manager = new TaskQueueManager<int>(maxTasks: 1);
+
+        manager.AddToQueue(1, _ => throw new InvalidOperationException("boom"));
+
+        var waitTask = Task.Run(() => manager.WaitForAll());
+        Assert.That(waitTask.Wait(TimeSpan.FromSeconds(5)), Is.True,
+            "WaitForAll should complete even when the work procedure throws");
+    }
+
+    [Test]
+    public void AddToQueue_LaterItemsRunAfterEarlierItemThrows()
+    {
+        using var manager = new TaskQueueManager<int>(maxTasks: 1);
+        var processed = new List<int>();
+        var lockObj = new object();
+
+        manager.AddToQueue(1, _ => throw new InvalidOperationException("boom"));
+        manager.AddToQueue(2, item =>
+        {
+            lock (lockObj) { processed.Add(item); }
+        });
+
+        var waitTask = Task.Run(() => manager.WaitForAll());
+        Assert.That(waitTask.Wait(TimeSpan.FromSeconds(5)), Is.True,
+            "WaitForAll should complete after the throwing work runs");
+        Assert.That(processed, Does.Contain(2),
+            "Subsequent queue items should run even after an earlier item throws");
+    }
+
+    [Test]
+    public void AddToQueue_QueueRecoversAfterAllWorkerSlotsFail()
+    {
+        using var manager = new TaskQueueManager<int>(maxTasks: 2);
+        var processed = new List<int>();
+        var lockObj = new object();
+
+        manager.AddToQueue(1, _ => throw new InvalidOperationException("boom1"));
+        manager.AddToQueue(2, _ => throw new InvalidOperationException("boom2"));
+        manager.AddToQueue(3, item =>
+        {
+            lock (lockObj) { processed.Add(item); }
+        });
+
+        var waitTask = Task.Run(() => manager.WaitForAll());
+        Assert.That(waitTask.Wait(TimeSpan.FromSeconds(5)), Is.True,
+            "WaitForAll should complete after every worker slot's task has failed");
+        Assert.That(processed, Does.Contain(3),
+            "New items should still execute after every worker slot has failed");
     }
 
     [Test]

--- a/Schema/Utility/TaskQueueManager.cs
+++ b/Schema/Utility/TaskQueueManager.cs
@@ -93,8 +93,17 @@ public class TaskQueueManager<T> : IDisposable
 
         private void DoWork()
         {
-            workProcedure(item);
-            owner.TaskComplete(this);
+            // TaskComplete must run unconditionally — otherwise an unhandled exception in
+            // workProcedure leaves this WorkerTask in _workingTasks forever, permanently
+            // reducing the queue's effective capacity and hanging WaitForAll.
+            try
+            {
+                workProcedure(item);
+            }
+            finally
+            {
+                owner.TaskComplete(this);
+            }
         }
 
         public void StartTask()


### PR DESCRIPTION
## Summary

`TaskQueueManager<T>.WorkerTask.DoWork` was:

```csharp
private void DoWork()
{
    workProcedure(item);     // if this throws...
    owner.TaskComplete(this); // ...this never runs
}
```

An unhandled exception in `workProcedure` left the failed `WorkerTask` in `_workingTasks` forever. Each failure permanently reduced the queue's effective capacity by one, and `WaitForAll()` hung forever once any work proc threw, since it loops on `_workingTasks.Count > 0`. After `maxTasks` failures, the queue was fully wedged — `ProcessQueue` couldn't dispatch new work because every worker slot was held by a faulted task.

All four real callers were silently exposed:

- `ProductQuench` — parallel server quench, parallel database quench
- `Template` — parallel per-table token resolution
- `ScriptFolder` — parallel SQL file load
- `TokenHelper` — parallel file-token resolution

Any exception escaping the work procedure would hang the entire quench / template-load / token-resolve operation.

## Fix

Wrap `workProcedure(item)` in `try/finally` so `TaskComplete(this)` always runs. The exception still surfaces as the Task's `Exception` property (unobserved by default, but visible via `TaskScheduler.UnobservedTaskException` for diagnostics). Callers continue to be responsible for handling errors inside their work procedures, as they already do (e.g., `TokenHelper` collects errors in a `ConcurrentBag<string>`).

## Tests (TDD)

Three new tests in `TaskQueueManagerTests` reproduce the bug:

- `WaitForAll_DoesNotHangWhenWorkThrows` — single throwing item; `WaitForAll` must complete within 5s.
- `AddToQueue_LaterItemsRunAfterEarlierItemThrows` — queue continues processing after one work proc throws.
- `AddToQueue_QueueRecoversAfterAllWorkerSlotsFail` — queue still dispatches new work after every worker slot has held a faulted task.

All three failed against `main` (5s timeout each → 15s total) and pass after the fix (~10ms total). All 1131 `Schema.UnitTests` + 78 `SchemaQuench.UnitTests` pass.

## Test plan

- [x] New tests fail against unfixed `DoWork` and pass after the `try/finally` is added
- [x] Full `Schema.UnitTests` suite (1131 tests) green
- [x] Full `SchemaQuench.UnitTests` suite (78 tests) green
- [ ] Reviewer sanity-check: confirm no caller relies on `WaitForAll` propagating exceptions (all four current callers handle errors inside the work proc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)