### PR TITLE
Fix product-level script routing for secondary servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For full release details and download links, see [GitHub Releases](https://githu
 
 ### Fixed
 
+- **Product-level script routing for SQL Server secondary servers** — Product-level script folders configured for secondary servers now open the command against the routed server instead of always using the primary server connection.
 - **TaskQueueManager wedge on uncaught work-procedure exceptions** — When a work procedure threw, the failed worker was never removed from the queue's working set, hanging `WaitForAll` and reducing effective capacity by one per failure. Parallel work in `ProductQuench` (server/database quench), `Template` (per-table token resolution), `ScriptFolder` (parallel file load), and `TokenHelper` (file-token resolution) could silently hang on any uncaught exception inside a work item. The worker now wraps the work procedure in `try`/`finally` so the completion handshake always runs.
 
 ## [v2.0.0](https://github.com/Schema-Smith/SchemaSmith/releases/tag/v2.0.0) — 2026-05-06

--- a/SchemaQuench/ProductQuench.cs
+++ b/SchemaQuench/ProductQuench.cs
@@ -144,7 +144,7 @@ public class ProductQuench
         Server = server
     };
 
-    private IDbCommand GetCommand(string server)
+    internal virtual IDbCommand GetCommand(string server)
     {
         var initDb = GetInitDatabase(_product.Platform);
         var connectionStringOverride = CommandLineParser.ValueOfSwitch("ConnectionString", null);
@@ -402,7 +402,7 @@ public class ProductQuench
     private void QuenchScriptsToServerWithCheckpoint(string server, string message, IEnumerable<SqlScript> scripts, bool isBefore)
     {
         _progressLog.Info($"Quenching {message} Scripts to {server}");
-        using var productScriptCommand = GetCommand(_primaryServer);
+        using var productScriptCommand = GetCommand(server);
         try
         {
             var scriptsToQuench = scripts.Select(j => j.Clone()).ToList();

--- a/SchemaQuench/SchemaQuench.UnitTests/ProductQuenchTests.cs
+++ b/SchemaQuench/SchemaQuench.UnitTests/ProductQuenchTests.cs
@@ -1,9 +1,16 @@
 // Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
 using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
 using NUnit.Framework;
 using Schema.Domain;
+using Schema.Isolators;
 
 namespace SchemaQuench.UnitTests;
 
@@ -85,6 +92,82 @@ public class ProductQuenchTests
     public void SpecialTokenTags_ContainsIndexedViewSchema()
     {
         Assert.That(ProductQuench.SpecialTokenTags, Does.Contain("IndexedViewSchema_"));
+    }
+
+    #endregion
+
+    #region Product Script Server Routing Tests
+
+    [Test]
+    public void QuenchScriptsToServerWithCheckpoint_UsesRequestedServerForCommand()
+    {
+        lock (FactoryContainer.SharedLockObject)
+        {
+            FactoryContainer.Clear();
+            var schemaPackagePath = "Product";
+            var productPath = Path.Combine(schemaPackagePath, "Product.json");
+            var file = Substitute.For<IFile>();
+            var directory = Substitute.For<IDirectory>();
+
+            file.Exists(schemaPackagePath).Returns(false);
+            directory.Exists(schemaPackagePath).Returns(true);
+            file.Exists(productPath).Returns(true);
+            file.ReadAllText(productPath).Returns("""
+                                                  {
+                                                    "Name": "TestProduct",
+                                                    "Platform": "SqlServer",
+                                                    "ScriptFolders": []
+                                                  }
+                                                  """);
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["SchemaPackagePath"] = schemaPackagePath,
+                    ["Target:Server"] = "primary-server",
+                    ["Target:SecondaryServers"] = "secondary-server",
+                    ["WhatIfONLY"] = "true"
+                })
+                .Build();
+
+            FactoryContainer.Register<IConfigurationRoot>(config);
+            FactoryContainer.Register<IFile>(file);
+            FactoryContainer.Register<IDirectory>(directory);
+
+            try
+            {
+                var quench = new RecordingProductQuench();
+
+                InvokeQuenchScriptsToServerWithCheckpoint(quench, "secondary-server");
+
+                Assert.That(quench.CommandServers, Is.EqualTo(new[] { "secondary-server" }));
+            }
+            finally
+            {
+                FactoryContainer.Clear();
+            }
+        }
+    }
+
+    private static void InvokeQuenchScriptsToServerWithCheckpoint(ProductQuench quench, string server)
+    {
+        var method = typeof(ProductQuench).GetMethod("QuenchScriptsToServerWithCheckpoint",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        method!.Invoke(quench, [server, "Before Product", Array.Empty<SqlScript>(), true]);
+    }
+
+    private sealed class RecordingProductQuench : ProductQuench
+    {
+        public List<string> CommandServers { get; } = [];
+
+        internal override IDbCommand GetCommand(string server)
+        {
+            CommandServers.Add(server);
+            var command = Substitute.For<IDbCommand>();
+            command.Connection.Returns(Substitute.For<IDbConnection>());
+            return command;
+        }
     }
 
     #endregion


### PR DESCRIPTION
Fixes #231.

## Summary

- route product-level script execution through the target `server` argument instead of always using `_primaryServer`
- keep the existing primary/secondary folder filtering behavior unchanged
- add a focused regression test for secondary-server command routing

## Testing

- `dotnet test SchemaQuench\SchemaQuench.UnitTests\SchemaQuench.UnitTests.csproj -c Debug --no-restore` — passed, 79 tests