### PR TITLE
Clean publish/ and verify ICU native assets in build-schemaquench

### DIFF
--- a/build-schemaquench.cmd
+++ b/build-schemaquench.cmd
@@ -12,6 +12,28 @@ if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
 
 echo   Architecture: %RID%
 
+:: Read <IcuVersion> from Directory.Build.props so the verification below stays in
+:: lockstep with the package version. Single source of truth.
+set ICU_VERSION=
+for /f "tokens=2 delims=<>" %%V in ('findstr /R "<IcuVersion>" "%~dp0Directory.Build.props"') do (
+    if /I "%%V"=="IcuVersion" (
+        rem skip the opening tag itself; the value is in the next token
+    ) else (
+        set ICU_VERSION=%%V
+    )
+)
+if "%ICU_VERSION%"=="" (
+    echo BUILD FAILED: Could not read ^<IcuVersion^> from Directory.Build.props.
+    exit /b 1
+)
+
+:: Clean publish/ so NuGet native runtime assets (libicu*.so) are always re-staged.
+:: Incremental dotnet publish skips re-copying package native assets when MSBuild
+:: considers the project up-to-date, which can leave publish/ missing the ICU
+:: libraries and crash the Linux container at the first globalization call with
+:: "Failed to load app-local ICU: libicudata.so.<IcuVersion>".
+if exist "%~dp0SchemaQuench\publish" rmdir /s /q "%~dp0SchemaQuench\publish"
+
 dotnet publish "%~dp0SchemaQuench\SchemaQuench.csproj" -c Release -r %RID% --self-contained -o "%~dp0SchemaQuench\publish"
 if %ERRORLEVEL% neq 0 (
     echo BUILD FAILED
@@ -22,6 +44,14 @@ if not exist "%~dp0SchemaQuench\publish\SchemaQuench" (
     echo BUILD FAILED: SchemaQuench\publish\SchemaQuench was not produced. Check the dotnet publish output above.
     echo Likely cause: .NET 10 SDK is not installed, or a NuGet restore step failed silently.
     exit /b 1
+)
+
+for %%I in (libicudata libicui18n libicuuc) do (
+    if not exist "%~dp0SchemaQuench\publish\%%I.so.%ICU_VERSION%" (
+        echo BUILD FAILED: %%I.so.%ICU_VERSION% missing from publish\ -- Microsoft.ICU.ICU4C.Runtime native assets were not staged.
+        echo Likely cause: NuGet restore did not pull the linux runtime native assets for this RID.
+        exit /b 1
+    )
 )
 
 echo   Build complete: SchemaQuench/publish/

--- a/build-schemaquench.sh
+++ b/build-schemaquench.sh
@@ -14,6 +14,22 @@ esac
 echo "  Architecture: $RID"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Read $(IcuVersion) from Directory.Build.props so the verification below stays in
+# lockstep with the package version. Single source of truth.
+ICU_VERSION=$(sed -n 's:.*<IcuVersion>\(.*\)</IcuVersion>.*:\1:p' "$SCRIPT_DIR/Directory.Build.props")
+if [ -z "$ICU_VERSION" ]; then
+    echo "BUILD FAILED: Could not read <IcuVersion> from Directory.Build.props."
+    exit 1
+fi
+
+# Clean publish/ so NuGet native runtime assets (libicu*.so) are always re-staged.
+# Incremental dotnet publish skips re-copying package native assets when MSBuild
+# considers the project up-to-date, which can leave publish/ missing the ICU
+# libraries and crash the Linux container at the first globalization call with
+# "Failed to load app-local ICU: libicudata.so.$IcuVersion".
+rm -rf "$SCRIPT_DIR/SchemaQuench/publish"
+
 dotnet publish "$SCRIPT_DIR/SchemaQuench/SchemaQuench.csproj" -c Release -r "$RID" --self-contained -o "$SCRIPT_DIR/SchemaQuench/publish"
 
 if [ ! -f "$SCRIPT_DIR/SchemaQuench/publish/SchemaQuench" ]; then
@@ -21,5 +37,13 @@ if [ ! -f "$SCRIPT_DIR/SchemaQuench/publish/SchemaQuench" ]; then
     echo "Likely cause: .NET 10 SDK is not installed, or a NuGet restore step failed silently."
     exit 1
 fi
+
+for icu in libicudata libicui18n libicuuc; do
+    if [ ! -f "$SCRIPT_DIR/SchemaQuench/publish/${icu}.so.${ICU_VERSION}" ]; then
+        echo "BUILD FAILED: ${icu}.so.${ICU_VERSION} missing from publish/ — Microsoft.ICU.ICU4C.Runtime native assets were not staged."
+        echo "Likely cause: NuGet restore did not pull the linux runtime native assets for this RID."
+        exit 1
+    fi
+done
 
 echo "  Build complete: SchemaQuench/publish/"


### PR DESCRIPTION
Both build-schemaquench scripts ran `dotnet publish ... -o publish` without cleaning the output directory first. On a subsequent run where MSBuild considered the project up-to-date, `dotnet publish` skipped re-copying the Microsoft.ICU.ICU4C.Runtime native assets — so if `libicu*.so.<IcuVersion>` were missing from `publish/` for any reason (manual cleanup, stale obj/, prior partial run), they stayed missing. The SchemaQuench binary still landed, the script's existence check passed, and the demo container then crashed at the first globalization call with:

  Process terminated.
  Failed to load app-local ICU: libicudata.so.72.1.0.3
     at System.Environment.FailFast(...)
     ...
     at System.Globalization.GlobalizationMode+Settings..cctor()
     ...
     at SchemaQuench.Program.Main(String[])

Repro on macOS arm64:
  $ rm SchemaQuench/publish/libicu*.so.72.1.0.3
  $ ./build-schemaquench.sh
  # publish/ still missing all three .so files; container crashes at startup

Fix:
- Remove SchemaQuench/publish/ before running dotnet publish so the package's native runtime assets are always re-staged.
- Read $(IcuVersion) from Directory.Build.props (single source of truth) and verify libicudata/libicui18n/libicuuc .so.<IcuVersion> all landed in publish/, failing loudly with a clear cause hint if any are missing.