### PR TITLE
Docs/demos readme align with launcher

### DIFF
--- a/Demos/README.md
+++ b/Demos/README.md
@@ -13,7 +13,22 @@ Demo database schema packages for SQL Server, PostgreSQL, and MySQL, deployed by
 
 ## Quick Start
 
-Choose a platform and run the matching launcher:
+Choose a platform and run the matching launcher.
+
+Windows (cmd):
+
+```cmd
+:: SQL Server
+cd SqlServer && run-demo.cmd
+
+:: PostgreSQL
+cd PostgreSQL && run-demo.cmd
+
+:: MySQL
+cd MySQL && run-demo.cmd
+```
+
+macOS / Linux (bash):
 
 ```bash
 # SQL Server
@@ -26,7 +41,7 @@ cd PostgreSQL && ./run-demo.sh
 cd MySQL && ./run-demo.sh
 ```
 
-On Windows, use `run-demo.cmd` in place of `run-demo.sh`. The launcher publishes SchemaQuench from source (via `build-schemaquench.sh` / `.cmd` — requires the .NET SDK on the host), then runs `docker compose up --build -d` to start the database server and deploy the demo schemas.
+The launcher publishes SchemaQuench from source (via `build-schemaquench.cmd` / `.sh` — requires the .NET SDK on the host), then runs `docker compose up --build -d` to start the database server and deploy the demo schemas.
 
 Each platform folder contains:
 - Demo schema packages (product folders)

--- a/Demos/README.md
+++ b/Demos/README.md
@@ -13,25 +13,26 @@ Demo database schema packages for SQL Server, PostgreSQL, and MySQL, deployed by
 
 ## Quick Start
 
-Choose a platform and run:
+Choose a platform and run the matching launcher:
 
 ```bash
 # SQL Server
-cd SqlServer && docker compose pull && docker compose build && docker compose up
+cd SqlServer && ./run-demo.sh
 
 # PostgreSQL
-cd PostgreSQL && docker compose pull && docker compose up
+cd PostgreSQL && ./run-demo.sh
 
 # MySQL
-cd MySQL && docker compose pull && docker compose up
+cd MySQL && ./run-demo.sh
 ```
+
+On Windows, use `run-demo.cmd` in place of `run-demo.sh`. The launcher publishes SchemaQuench from source (via `build-schemaquench.sh` / `.cmd` — requires the .NET SDK on the host), then runs `docker compose up --build -d` to start the database server and deploy the demo schemas.
 
 Each platform folder contains:
 - Demo schema packages (product folders)
 - A `docker-compose.yml` that spins up the database server and runs SchemaQuench to deploy the demo schemas
+- A `run-demo.sh` / `run-demo.cmd` launcher
 - A `.env` file with default credentials
-
-SQL Server requires `docker compose build` because it uses a custom Dockerfile to install Full-Text Search.
 
 ## Sources & Licensing
 


### PR DESCRIPTION
## Summary
  
  - Replace the `Demos/README.md` Quick Start with the same `cd Demos/<platform> && run-demo.{cmd,sh}` form already used in the root `README.md` and the end-user Quick
  Start guide, so the three docs agree on one canonical way to launch the demos.
  - Present the launcher commands as Windows-first dual code blocks (`cmd` then `bash`) rather than a single bash block with an "on Windows, use .cmd" footnote — clearer
   copy/paste for the majority of users.
  - Drop the misleading "SQL Server requires `docker compose build` because of FTS" caveat. The launchers run `docker compose up --build -d` uniformly across all three
  platforms, so the caveat reinforced a wrong impression that PG/MySQL didn't need a build step.

  ## Why
  
  The previous Quick Start documented raw `docker compose pull && docker compose build && docker compose up` commands that did not work on a fresh clone:

  1. They never mentioned `build-schemaquench.sh`, but `Dockerfile.release` does `COPY publish/ .` and `SchemaQuench/publish/` is gitignored — so `docker compose build`
  failed with `"/publish": not found`.
  2. The PostgreSQL and MySQL recipes omitted `docker compose build` entirely, even though every `quench-*` service has a `build:` directive and would have no image to
  run.

  The launchers (`run-demo.sh` / `run-demo.cmd`) already chain `build-schemaquench` → `docker compose up --build -d` and are what the rest of the docs point at; aligning
   `Demos/README.md` removes the divergence.

  ## Test plan
  
  - [ ] On a fresh clone, follow Quick Start verbatim on macOS (`cd Demos/SqlServer && ./run-demo.sh`) — demo comes up, AdventureWorks deploys, `completed` service exits
   0.
  - [ ] Same on Windows (`cd Demos\SqlServer && run-demo.cmd`).
  - [ ] Repeat for `PostgreSQL` and `MySQL`.
  - [ ] Verify the new Quick Start renders correctly on GitHub (two code blocks side by side in the markdown, cmd block first).