### PR TITLE
Fix IcuVersion parser in build-schemaquench.cmd

### DIFF
--- a/build-schemaquench.cmd
+++ b/build-schemaquench.cmd
@@ -13,14 +13,12 @@ if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
 echo   Architecture: %RID%
 
 :: Read <IcuVersion> from Directory.Build.props so the verification below stays in
-:: lockstep with the package version. Single source of truth.
+:: lockstep with the package version. Single source of truth. Splitting the
+:: matched line on `<` and `>` yields four tokens — leading whitespace, opening
+:: tag name, value, closing tag name — so token 3 is the version.
 set ICU_VERSION=
-for /f "tokens=2 delims=<>" %%V in ('findstr /R "<IcuVersion>" "%~dp0Directory.Build.props"') do (
-    if /I "%%V"=="IcuVersion" (
-        rem skip the opening tag itself; the value is in the next token
-    ) else (
-        set ICU_VERSION=%%V
-    )
+for /f "tokens=3 delims=<>" %%V in ('findstr /R "<IcuVersion>" "%~dp0Directory.Build.props"') do (
+    set ICU_VERSION=%%V
 )
 if "%ICU_VERSION%"=="" (
     echo BUILD FAILED: Could not read ^<IcuVersion^> from Directory.Build.props.


### PR DESCRIPTION
PR #237's IcuVersion read used `tokens=2 delims=<>`, which assigns the opening tag name (`IcuVersion`) to %%V — not the version value. The `for /f "tokens=N"` form only binds a single token to the loop variable; the if/else guard meant to skip the tag name and pick "the next token" had no next token to pick, so the else-branch where ICU_VERSION gets set was unreachable. Every invocation hit:

  BUILD FAILED: Could not read <IcuVersion> from Directory.Build.props.

…which blocked the entire Windows demo path (`run-demo.cmd` for any of SQL Server, PostgreSQL, MySQL). The bash counterpart is fine — sed captures the value group directly.

Splitting `    <IcuVersion>72.1.0.3</IcuVersion>` on `<` and `>` yields
four tokens — leading whitespace, opening tag name, value, closing tag
name — so `tokens=3` reliably captures the version and removes the need
for the if/else filter entirely.

Verified by running build-schemaquench.cmd on a wiped publish/ folder (all four files staged, including libicu*.so.72.1.0.3) and by an end-to-end run-demo.cmd on the PostgreSQL demo from a Windows shell (all four quench services exited 0).