### PR TITLE
fix(checkpoint): unwrap MissingTablesAndColumns from _checkpointing.Track + add three conditional-deployment demos for the 6/11 article

### DIFF
--- a/Demos/Conditional/MySQL-VersionGate/.env
+++ b/Demos/Conditional/MySQL-VersionGate/.env
@@ -1,0 +1,3 @@
+MYSQL_ROOT_PASSWORD=demo_root_pwd
+MYSQL_USER=demo_user
+MYSQL_PASSWORD=demo_password

--- a/Demos/Conditional/MySQL-VersionGate/Package/Product.json
+++ b/Demos/Conditional/MySQL-VersionGate/Package/Product.json
@@ -1,0 +1,12 @@
+{
+  "Name": "ConditionalMysqlDemo",
+  "ValidationScript": "SELECT TRUE",
+  "TemplateOrder": [
+    "Main"
+  ],
+  "ScriptTokens": {
+    "DemoDb": "conditional_demo"
+  },
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Tables/Documents.json
+++ b/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Tables/Documents.json
@@ -1,0 +1,25 @@
+{
+  "Name": "Documents",
+  "Columns": [
+    {
+      "Name": "DocumentId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "Title",
+      "DataType": "VARCHAR(200)"
+    },
+    {
+      "Name": "Body",
+      "DataType": "TEXT",
+      "Nullable": true
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "IndexColumns": "DocumentId"
+    }
+  ]
+}

--- a/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Tables/Embeddings.json
+++ b/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Tables/Embeddings.json
@@ -1,0 +1,42 @@
+{
+  "Name": "Embeddings",
+  "Columns": [
+    {
+      "Name": "EmbeddingId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "DocumentId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "Model",
+      "DataType": "VARCHAR(64)"
+    },
+    {
+      "Name": "Embedding",
+      "DataType": "VECTOR(384)",
+      "Nullable": true,
+      "ShouldApplyExpression": "CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED) >= 9"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "IndexColumns": "EmbeddingId"
+    },
+    {
+      "Name": "ix_embeddings_document",
+      "IndexColumns": "DocumentId"
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "fk_embeddings_documents",
+      "Columns": "DocumentId",
+      "RelatedTable": "Documents",
+      "RelatedColumns": "DocumentId"
+    }
+  ]
+}

--- a/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Template.json
+++ b/Demos/Conditional/MySQL-VersionGate/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '{{DemoDb}}'",
+  "ScriptFolders": []
+}

--- a/Demos/Conditional/MySQL-VersionGate/README.md
+++ b/Demos/Conditional/MySQL-VersionGate/README.md
@@ -1,0 +1,71 @@
+# MySQL Version-Gate Demo
+
+One schema package. Two MySQL versions. Different deployed shapes — driven by the schema package, not by the CI script.
+
+## What's in here
+
+A small SchemaSmith schema package — two tables (`Documents`, `Embeddings`) — designed to deploy successfully against **MySQL 8.0** (the SchemaSmith floor) and **MySQL 9** (current) from the same package.
+
+The catch: `Embeddings.Embedding` is a `VECTOR(384)` column for storing model embeddings. The `VECTOR` data type landed in **MySQL 9** — it doesn't exist in MySQL 8.0. So the column carries a `ShouldApplyExpression` the engine itself evaluates at deploy time:
+
+```json
+{
+  "Name": "Embedding",
+  "DataType": "VECTOR(384)",
+  "Nullable": true,
+  "ShouldApplyExpression": "CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED) >= 9"
+}
+```
+
+MySQL 8.0 evaluates `major-version >= 9` as **false** and skips the column. MySQL 9 evaluates it as **true** and applies the column with the native `vector(384)` type.
+
+## Running it
+
+```bash
+./run-demo.sh        # macOS / Linux
+run-demo.cmd         # Windows
+```
+
+The launcher publishes SchemaQuench, brings up `docker compose`, and runs the deploy against both MySQL containers in parallel. When both are done, a final verification service prints both `Embeddings` table schemas side by side.
+
+Expected output (the bottom half):
+
+```
+--- MySQL 8.0 (VERSION() major < 9): Embedding column SKIPPED ---
++-------------+------------+------+-----+---------+-------+
+| Field       | Type       | Null | Key | Default | Extra |
++-------------+------------+------+-----+---------+-------+
+| EmbeddingId | bigint     | NO   | PRI | NULL    |       |
+| DocumentId  | bigint     | NO   | MUL | NULL    |       |
+| Model       | varchar(64)| NO   |     | NULL    |       |
++-------------+------------+------+-----+---------+-------+
+
+--- MySQL 9 (VERSION() major >= 9): Embedding column APPLIED as VECTOR(384) ---
++-------------+-------------+------+-----+---------+-------+
+| Field       | Type        | Null | Key | Default | Extra |
++-------------+-------------+------+-----+---------+-------+
+| EmbeddingId | bigint      | NO   | PRI | NULL    |       |
+| DocumentId  | bigint      | NO   | MUL | NULL    |       |
+| Model       | varchar(64) | NO   |     | NULL    |       |
+| Embedding   | vector(384) | YES  |     | NULL    |       |
++-------------+-------------+------+-----+---------+-------+
+```
+
+Negative control: try `CREATE TABLE foo (e VECTOR(384));` against MySQL 8.0 directly — it errors with `You have an error in your SQL syntax`. The feature gap is real; the demo shows SchemaSmith handling it gracefully without manual version checks in the CI script.
+
+## Why this matters
+
+If your application footprint mixes MySQL 8.0 (LTS, still in long support through 2026) and MySQL 9 (innovation release), and you want to start using `VECTOR` columns for AI embeddings on the 9.x boxes, the conventional approach is to fork your migration files or wrap them in shell-script version checks. With SchemaSmith's `ShouldApplyExpression`, the version check lives **in the schema package**, evaluated by the target engine at deploy time. Same CI script. Same deploy artifact. Different schemas where the engine supports the difference.
+
+## Cleanup
+
+```bash
+docker compose down --volumes
+```
+
+## Related
+
+- Article: *The Production Server That Can't Be Upgraded — and the Deployment Pipeline That Has to Live With It* (LinkedIn, 2026-06-11)
+- Sister demos:
+  - [`../PostgreSQL-VersionGate`](../PostgreSQL-VersionGate) — same version-gate shape on PostgreSQL, gating a virtual generated column on PG18+
+  - [`../SqlServer-RollingRollout`](../SqlServer-RollingRollout) — rolling NCCI rollout across tenant databases (state-based gating, not version-based)

--- a/Demos/Conditional/MySQL-VersionGate/docker-compose.yml
+++ b/Demos/Conditional/MySQL-VersionGate/docker-compose.yml
@@ -1,0 +1,103 @@
+name: schemasmith-conditional-mysql-demo
+
+# Conditional deployment demo: same schema package deploys against MySQL 8.0
+# (the SchemaSmith floor) and MySQL 9 (current). An Embeddings.Embedding
+# column declared as VECTOR(384) is gated by
+# `CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED) >= 9` -- the VECTOR
+# type landed in MySQL 9, so MySQL 8.0 skips the column entirely and the
+# table lands without it. MySQL 9 applies the full schema.
+
+services:
+  mysql8:
+    image: mysql:8.0
+    # log-bin-trust-function-creators=1 lets a non-SUPER user (the demo user) create the
+    # stored functions SchemaSmith's KindleTheForge installs. Without it, MySQL rejects
+    # CREATE FUNCTION because binary logging is on by default and non-SUPER users could
+    # in principle write non-deterministic functions that desync the binlog.
+    command: --log-bin-trust-function-creators=1
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: conditional_demo
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD} --silent && mysql -h 127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1' >/dev/null 2>&1"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "3308:3306"
+
+  mysql9:
+    image: mysql:9
+    command: --log-bin-trust-function-creators=1
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: conditional_demo
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD} --silent && mysql -h 127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1' >/dev/null 2>&1"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "3309:3306"
+
+  quench-mysql8:
+    build:
+      context: ../../../SchemaQuench
+      dockerfile: Dockerfile.release
+    environment:
+      - SmithySettings_Target__Server=mysql8
+      - SmithySettings_Target__User=${MYSQL_USER}
+      - SmithySettings_Target__Password=${MYSQL_PASSWORD}
+      - SmithySettings_SchemaPackagePath=/metadata
+    volumes:
+      - ./Package:/metadata
+    depends_on:
+      mysql8:
+        condition: service_healthy
+
+  quench-mysql9:
+    build:
+      context: ../../../SchemaQuench
+      dockerfile: Dockerfile.release
+    environment:
+      - SmithySettings_Target__Server=mysql9
+      - SmithySettings_Target__User=${MYSQL_USER}
+      - SmithySettings_Target__Password=${MYSQL_PASSWORD}
+      - SmithySettings_SchemaPackagePath=/metadata
+    volumes:
+      - ./Package:/metadata
+    depends_on:
+      mysql9:
+        condition: service_healthy
+
+  verify:
+    image: mysql:9
+    environment:
+      MYSQL_PWD: ${MYSQL_PASSWORD}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        echo
+        echo '=================================================================='
+        echo '  Verification: same schema package, two MySQL versions'
+        echo '=================================================================='
+        echo
+        echo '--- MySQL 8.0 (VERSION() major < 9): Embedding column SKIPPED ---'
+        mysql -h mysql8 -u${MYSQL_USER} -D conditional_demo -e "DESCRIBE Embeddings;"
+        echo
+        echo '--- MySQL 9 (VERSION() major >= 9): Embedding column APPLIED as VECTOR(384) ---'
+        mysql -h mysql9 -u${MYSQL_USER} -D conditional_demo -e "DESCRIBE Embeddings;"
+        echo
+        echo 'Single schema package. Two engine versions. Different schemas.'
+        echo 'ShouldApplyExpression in the column JSON did the version gating.'
+        echo
+    depends_on:
+      quench-mysql8:
+        condition: service_completed_successfully
+      quench-mysql9:
+        condition: service_completed_successfully

--- a/Demos/Conditional/MySQL-VersionGate/run-demo.cmd
+++ b/Demos/Conditional/MySQL-VersionGate/run-demo.cmd
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\..\.."
+set "REPO_ROOT=%CD%"
+popd
+
+echo Publishing SchemaQuench...
+call "%REPO_ROOT%\build-schemaquench.cmd"
+if errorlevel 1 exit /b %errorlevel%
+
+echo Starting MySQL conditional-deployment demo...
+cd /d "%SCRIPT_DIR%"
+
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/Conditional/MySQL-VersionGate/run-demo.sh
+++ b/Demos/Conditional/MySQL-VersionGate/run-demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../.."
+
+echo "Publishing SchemaQuench..."
+"$REPO_ROOT/build-schemaquench.sh"
+
+echo "Starting MySQL conditional-deployment demo..."
+cd "$SCRIPT_DIR"
+
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/Conditional/PostgreSQL-VersionGate/.env
+++ b/Demos/Conditional/PostgreSQL-VersionGate/.env
@@ -1,0 +1,2 @@
+POSTGRES_USER=demo_user
+POSTGRES_PASSWORD=demo_password

--- a/Demos/Conditional/PostgreSQL-VersionGate/Package/Product.json
+++ b/Demos/Conditional/PostgreSQL-VersionGate/Package/Product.json
@@ -1,0 +1,12 @@
+{
+  "Name": "ConditionalPostgresDemo",
+  "ValidationScript": "SELECT TRUE",
+  "TemplateOrder": [
+    "Main"
+  ],
+  "ScriptTokens": {
+    "DemoDb": "conditional_demo"
+  },
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.Customers.json
+++ b/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.Customers.json
@@ -1,0 +1,31 @@
+{
+  "Schema": "public",
+  "Name": "Customers",
+  "Columns": [
+    {
+      "Name": "CustomerId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "Email",
+      "DataType": "VARCHAR(254)"
+    },
+    {
+      "Name": "DisplayName",
+      "DataType": "VARCHAR(120)",
+      "Nullable": true
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_customers",
+      "PrimaryKey": true,
+      "IndexColumns": "CustomerId"
+    },
+    {
+      "Name": "uq_customers_email",
+      "Unique": true,
+      "IndexColumns": "Email"
+    }
+  ]
+}

--- a/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.OrderEvents.json
+++ b/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.OrderEvents.json
@@ -1,0 +1,36 @@
+{
+  "Schema": "public",
+  "Name": "OrderEvents",
+  "Columns": [
+    {
+      "Name": "EventId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "OccurredAt",
+      "DataType": "TIMESTAMPTZ",
+      "Default": "now()"
+    },
+    {
+      "Name": "Payload",
+      "DataType": "JSONB",
+      "Nullable": true
+    },
+    {
+      "Name": "Status",
+      "DataType": "TEXT",
+      "Nullable": true,
+      "Generated": "ALWAYS",
+      "GenerationExpression": "(\"Payload\"->>'status')",
+      "Virtual": true,
+      "ShouldApplyExpression": "current_setting('server_version_num')::int >= 180000"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_orderevents",
+      "PrimaryKey": true,
+      "IndexColumns": "EventId"
+    }
+  ]
+}

--- a/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.Orders.json
+++ b/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Tables/public.Orders.json
@@ -1,0 +1,39 @@
+{
+  "Schema": "public",
+  "Name": "Orders",
+  "Columns": [
+    {
+      "Name": "OrderId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "CustomerId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "OrderedAt",
+      "DataType": "TIMESTAMPTZ",
+      "Default": "now()"
+    },
+    {
+      "Name": "TotalCents",
+      "DataType": "BIGINT",
+      "Nullable": true
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_orders",
+      "PrimaryKey": true,
+      "IndexColumns": "OrderId"
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "fk_orders_customers",
+      "Columns": "CustomerId",
+      "RelatedTable": "Customers",
+      "RelatedColumns": "CustomerId"
+    }
+  ]
+}

--- a/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Template.json
+++ b/Demos/Conditional/PostgreSQL-VersionGate/Package/Templates/Main/Template.json
@@ -1,0 +1,6 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = '{{DemoDb}}'",
+  "VersionStampScript": "DO $$ BEGIN RAISE NOTICE 'ConditionalPostgresDemo deployed'; END; $$;",
+  "ScriptFolders": []
+}

--- a/Demos/Conditional/PostgreSQL-VersionGate/README.md
+++ b/Demos/Conditional/PostgreSQL-VersionGate/README.md
@@ -1,0 +1,73 @@
+# PostgreSQL Version-Gate Demo
+
+One schema package. Two PostgreSQL versions. Different deployed shapes — driven by the schema package, not by the CI script.
+
+## What's in here
+
+A small SchemaSmith schema package — three tables (`Customers`, `Orders`, `OrderEvents`) — designed to deploy successfully against **PostgreSQL 15** (the SchemaSmith floor) and **PostgreSQL 18** (the current major) from the same package.
+
+The catch: `OrderEvents.Status` is a **virtual generated column** that extracts a path out of the `Payload` JSONB. Virtual generated columns landed in PostgreSQL 18; PG15 doesn't have them. So the column carries a `ShouldApplyExpression` the engine itself evaluates at deploy time:
+
+```json
+{
+  "Name": "Status",
+  "DataType": "TEXT",
+  "Nullable": true,
+  "Generated": "ALWAYS",
+  "GenerationExpression": "(Payload->>'status')",
+  "Virtual": true,
+  "ShouldApplyExpression": "current_setting('server_version_num')::int >= 180000"
+}
+```
+
+PG15 evaluates `current_setting('server_version_num')::int >= 180000` as **false** and skips the column. PG18 evaluates it as **true** and applies the column with `attgenerated = 'v'` (the marker that confirms it's a true virtual generated column, not a stored fallback).
+
+## Running it
+
+```bash
+./run-demo.sh        # macOS / Linux
+run-demo.cmd         # Windows
+```
+
+The launcher publishes SchemaQuench, brings up `docker compose`, and runs the deploy against both PG containers in parallel. When both are done, a final verification service prints both schemas side by side so you can see the gating happen.
+
+Expected output (the bottom half — see the launcher console for the full run):
+
+```
+--- PG15 (server_version_num < 180000): Status column SKIPPED ---
+ column_name | data_type | is_generated | generation_expression
+-------------+-----------+--------------+-----------------------
+ EventId     | bigint    | NEVER        |
+ OccurredAt  | timestamp with time zone | NEVER |
+ Payload     | jsonb     | NEVER        |
+
+--- PG18 (server_version_num >= 180000): Status column APPLIED ---
+    attgenerated = "v" confirms the column is truly VIRTUAL
+ column_name | data_type | is_generated |    generation_expression    | gen_marker
+-------------+-----------+--------------+-----------------------------+------------
+ EventId     | bigint    | NEVER        |                             |
+ OccurredAt  | ...       | NEVER        |                             |
+ Payload     | jsonb     | NEVER        |                             |
+ Status      | text      | ALWAYS       | (Payload ->> 'status'::text)| v
+```
+
+## Why this matters
+
+Most schema-management tools handle version differences by **branching the deployment pipeline** — environment-specific CI scripts, version-aware wrappers, hand-maintained "only on v18+" comment blocks. The decision about whether to apply a change ends up living *next to* the migration, not *in* it.
+
+SchemaSmith flips that. The condition lives **in the package**, evaluated by the target engine at deploy time. The CI pipeline is the same on PG15 and PG18. The deploy artifact is the same. The intelligence is in the SQL, not in the YAML.
+
+When this pattern works on every component type that supports `ShouldApplyExpression` (columns, indexes, foreign keys, check constraints, etc.), engine-version drift across your environments stops being a tax on every PR.
+
+## Cleanup
+
+```bash
+docker compose down --volumes
+```
+
+## Related
+
+- Article: *The Production Server That Can't Be Upgraded — and the Deployment Pipeline That Has to Live With It* (LinkedIn, 2026-06-11)
+- Sister demos:
+  - [`../SqlServer-RollingRollout`](../SqlServer-RollingRollout) — rolling NCCI rollout across tenant databases (state-based gating, not version-based)
+  - [`../MySQL-VersionGate`](../MySQL-VersionGate) — same version-gate shape on MySQL, gating a `VECTOR` column on MySQL 9+

--- a/Demos/Conditional/PostgreSQL-VersionGate/docker-compose.yml
+++ b/Demos/Conditional/PostgreSQL-VersionGate/docker-compose.yml
@@ -1,0 +1,109 @@
+name: schemasmith-conditional-pg-demo
+
+# Conditional deployment demo: same schema package deploys against PostgreSQL 15
+# (the SchemaSmith floor) and PostgreSQL 18 (the current major). A virtual
+# generated column on OrderEvents.Status is gated by
+# `current_setting('server_version_num')::int >= 180000` -- it skips on PG15
+# (virtual generated columns landed in PG18) and applies on PG18.
+
+services:
+  pg15:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: conditional_demo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d conditional_demo"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "5415:5432"
+
+  pg18:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: conditional_demo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d conditional_demo"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "5418:5432"
+
+  quench-pg15:
+    build:
+      context: ../../../SchemaQuench
+      dockerfile: Dockerfile.release
+    environment:
+      - SmithySettings_Target__Server=pg15
+      - SmithySettings_Target__User=${POSTGRES_USER}
+      - SmithySettings_Target__Password=${POSTGRES_PASSWORD}
+      - SmithySettings_SchemaPackagePath=/metadata
+    volumes:
+      - ./Package:/metadata
+    depends_on:
+      pg15:
+        condition: service_healthy
+
+  quench-pg18:
+    build:
+      context: ../../../SchemaQuench
+      dockerfile: Dockerfile.release
+    environment:
+      - SmithySettings_Target__Server=pg18
+      - SmithySettings_Target__User=${POSTGRES_USER}
+      - SmithySettings_Target__Password=${POSTGRES_PASSWORD}
+      - SmithySettings_SchemaPackagePath=/metadata
+    volumes:
+      - ./Package:/metadata
+    depends_on:
+      pg18:
+        condition: service_healthy
+
+  verify:
+    image: postgres:18
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        echo
+        echo '=================================================================='
+        echo '  Verification: same schema package, two PostgreSQL versions'
+        echo '=================================================================='
+        echo
+        echo '--- PG15 (server_version_num < 180000): Status column SKIPPED ---'
+        psql -h pg15 -U ${POSTGRES_USER} -d conditional_demo -c "
+          SELECT column_name, data_type, is_generated, generation_expression
+            FROM information_schema.columns
+           WHERE table_name = 'OrderEvents'
+           ORDER BY ordinal_position;
+        "
+        echo
+        echo '--- PG18 (server_version_num >= 180000): Status column APPLIED ---'
+        echo '    attgenerated = "v" confirms the column is truly VIRTUAL'
+        psql -h pg18 -U ${POSTGRES_USER} -d conditional_demo -c "
+          SELECT c.column_name, c.data_type, c.is_generated, c.generation_expression,
+                 a.attgenerated AS gen_marker
+            FROM information_schema.columns c
+            JOIN pg_attribute a
+              ON a.attname = c.column_name
+             AND a.attrelid = (SELECT oid FROM pg_class WHERE relname = c.table_name)
+           WHERE c.table_name = 'OrderEvents'
+           ORDER BY c.ordinal_position;
+        "
+        echo
+        echo 'Single schema package. Two engine versions. Different schemas.'
+        echo 'ShouldApplyExpression in the column JSON did the version gating.'
+        echo
+    depends_on:
+      quench-pg15:
+        condition: service_completed_successfully
+      quench-pg18:
+        condition: service_completed_successfully

--- a/Demos/Conditional/PostgreSQL-VersionGate/run-demo.cmd
+++ b/Demos/Conditional/PostgreSQL-VersionGate/run-demo.cmd
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\..\.."
+set "REPO_ROOT=%CD%"
+popd
+
+echo Publishing SchemaQuench...
+call "%REPO_ROOT%\build-schemaquench.cmd"
+if errorlevel 1 exit /b %errorlevel%
+
+echo Starting PostgreSQL conditional-deployment demo...
+cd /d "%SCRIPT_DIR%"
+
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/Conditional/PostgreSQL-VersionGate/run-demo.sh
+++ b/Demos/Conditional/PostgreSQL-VersionGate/run-demo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../.."
+
+echo "Publishing SchemaQuench..."
+"$REPO_ROOT/build-schemaquench.sh"
+
+echo "Starting PostgreSQL conditional-deployment demo..."
+cd "$SCRIPT_DIR"
+
+# `up` (foreground) lets the verify service's output reach the console.
+# The verify service blocks on both quench services completing, so by the
+# time the verify output prints, both deploys are done.
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/Conditional/README.md
+++ b/Demos/Conditional/README.md
@@ -1,0 +1,36 @@
+# Conditional Deployment Demos
+
+Three runnable demos showing `ShouldApplyExpression` on real engines. One schema package per demo, two or three engine targets per demo, observable difference in the deployed shape — all driven by the SQL expression in the schema package, not by branching the CI script.
+
+| Demo | Engine pair | Gated component | Condition |
+|---|---|---|---|
+| [PostgreSQL Version-Gate](PostgreSQL-VersionGate) | PG15 ↔ PG18 | Virtual generated column | `current_setting('server_version_num')::int >= 180000` |
+| [SQL Server Rolling-Rollout](SqlServer-RollingRollout) | SQL Server 2022 × 3 tenant DBs | Nonclustered columnstore index | `EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore' AND status = 'Ready')` |
+| [MySQL Version-Gate](MySQL-VersionGate) | MySQL 8.0 ↔ MySQL 9 | `VECTOR(384)` column | `CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED) >= 9` |
+
+Each demo is self-contained: schema package, `docker-compose.yml` with the engine pair (or single instance + multi-DB for the SQL Server one), launcher scripts (`run-demo.sh` / `run-demo.cmd`), and a one-page README with the expected output.
+
+## Running a demo
+
+```bash
+cd PostgreSQL-VersionGate      # or MySQL-VersionGate / SqlServer-RollingRollout
+./run-demo.sh                  # macOS / Linux
+run-demo.cmd                   # Windows
+```
+
+Each launcher publishes the SchemaQuench binary (via the existing `build-schemaquench.sh` / `.cmd` at the repo root), brings up the engines under `docker compose`, runs the deploy, and emits a verification block showing what landed where.
+
+Cleanup is `docker compose down --volumes` from inside the demo directory.
+
+## What you're seeing
+
+Two **version-gate** shapes (Postgres, MySQL) and one **state-gate** shape (SQL Server):
+
+- **Version-gate:** the same JSON column declaration carries an engine-version expression. Older engine evaluates it as false and skips the column; newer engine evaluates it as true and applies the column. The deploy artifact is identical; only the target engine's version differs.
+- **State-gate:** the same JSON index declaration carries an `EXISTS`-against-control-table expression. The "row" in `dbo.RolloutControl` is the DBA's per-database approval lever — flip it to `Ready` when a given tenant is approved for the heavy DDL in this maintenance window, leave it `Pending` otherwise. Same schema package on every deploy run; only the tenants the DBA has approved take on the index in any given window.
+
+Both shapes are exactly the conditional-deployment pattern described in the article *The Production Server That Can't Be Upgraded — and the Deployment Pipeline That Has to Live With It* (LinkedIn, 2026-06-11). The patterns recur across teams and stacks; SchemaSmith's role is to put the conditional logic **in the schema package**, in the language the target engine already speaks, instead of in a CI wrapper.
+
+## Article
+
+This is the demo bundle for the article. Open the article alongside the demos and the three "Run any of them in under ten minutes" claims are the demos in this directory.

--- a/Demos/Conditional/SqlServer-RollingRollout/.env
+++ b/Demos/Conditional/SqlServer-RollingRollout/.env
@@ -1,0 +1,1 @@
+MSSQL_SA_PASSWORD=Demo_StrongPassword_2026!

--- a/Demos/Conditional/SqlServer-RollingRollout/Package/Product.json
+++ b/Demos/Conditional/SqlServer-RollingRollout/Package/Product.json
@@ -1,0 +1,10 @@
+{
+  "Name": "ConditionalSqlServerDemo",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": [
+    "Main"
+  ],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Conditional/SqlServer-RollingRollout/Package/Templates/Main/Tables/dbo.OrderHistory.json
+++ b/Demos/Conditional/SqlServer-RollingRollout/Package/Templates/Main/Tables/dbo.OrderHistory.json
@@ -1,0 +1,42 @@
+{
+  "Schema": "dbo",
+  "Name": "OrderHistory",
+  "Columns": [
+    {
+      "Name": "OrderId",
+      "DataType": "BIGINT"
+    },
+    {
+      "Name": "TenantId",
+      "DataType": "INT"
+    },
+    {
+      "Name": "CustomerId",
+      "DataType": "INT"
+    },
+    {
+      "Name": "OrderDate",
+      "DataType": "DATETIME2"
+    },
+    {
+      "Name": "OrderTotal",
+      "DataType": "DECIMAL(18,2)"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PK_OrderHistory",
+      "PrimaryKey": true,
+      "Clustered": true,
+      "IndexColumns": "OrderId"
+    },
+    {
+      "Name": "NCCI_OrderHistory_Analytics",
+      "ColumnStore": true,
+      "Clustered": false,
+      "IncludeColumns": "TenantId, CustomerId, OrderDate, OrderTotal",
+      "CompressionType": "COLUMNSTORE",
+      "ShouldApplyExpression": "EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore' AND status = 'Ready')"
+    }
+  ]
+}

--- a/Demos/Conditional/SqlServer-RollingRollout/Package/Templates/Main/Template.json
+++ b/Demos/Conditional/SqlServer-RollingRollout/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name IN ('Tenant_A', 'Tenant_B', 'Tenant_C')",
+  "ScriptFolders": []
+}

--- a/Demos/Conditional/SqlServer-RollingRollout/README.md
+++ b/Demos/Conditional/SqlServer-RollingRollout/README.md
@@ -1,0 +1,101 @@
+# SQL Server Rolling-Rollout Demo
+
+One schema package. Three tenant databases. Heavy DDL rolled out one tenant per maintenance window — gated by a per-database `RolloutControl` row the DBA flips when each tenant is ready.
+
+## What's in here
+
+A small SchemaSmith schema package targeting three tenant databases (`Tenant_A`, `Tenant_B`, `Tenant_C`) on a single SQL Server 2022 instance. The package declares an `OrderHistory` table and a **nonclustered columnstore index** on it for analytical queries. The NCCI is wrapped in a `ShouldApplyExpression` that checks a per-database `RolloutControl` table:
+
+```json
+{
+  "Name": "NCCI_OrderHistory_Analytics",
+  "ColumnStore": true,
+  "Clustered": false,
+  "IncludeColumns": "TenantId, CustomerId, OrderDate, OrderTotal",
+  "CompressionType": "COLUMNSTORE",
+  "ShouldApplyExpression": "EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore' AND status = 'Ready')"
+}
+```
+
+The demo bootstraps the three tenants with this initial state:
+
+| Database | `RolloutControl.status` |
+|---|---|
+| `Tenant_A` | `Ready` |
+| `Tenant_B` | `Pending` |
+| `Tenant_C` | `Pending` |
+
+## Running it
+
+```bash
+./run-demo.sh        # macOS / Linux
+run-demo.cmd         # Windows
+```
+
+The launcher publishes SchemaQuench, brings up `docker compose`, and runs the deploy against all three tenant databases. A final verification service prints what landed in each.
+
+Expected output (the bottom half):
+
+```
+--- Tenant_A ---
+ feature                   status
+ OrderHistoryColumnstore   Ready
+ index_name                       type_desc
+ PK_OrderHistory                  CLUSTERED
+ NCCI_OrderHistory_Analytics      NONCLUSTERED COLUMNSTORE
+
+--- Tenant_B ---
+ feature                   status
+ OrderHistoryColumnstore   Pending
+ index_name                       type_desc
+ PK_OrderHistory                  CLUSTERED
+
+--- Tenant_C ---
+ feature                   status
+ OrderHistoryColumnstore   Pending
+ index_name                       type_desc
+ PK_OrderHistory                  CLUSTERED
+```
+
+Same package. Three databases. One rollout pass. Only `Tenant_A` (the one approved for this window) picked up the heavy DDL.
+
+## Rolling to the next tenant
+
+To advance `Tenant_B` in a later maintenance window, flip its rollout row and re-run the quench:
+
+```bash
+docker compose exec demoserver /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -d Tenant_B -Q \
+  "UPDATE dbo.RolloutControl SET status = 'Ready' WHERE feature = 'OrderHistoryColumnstore';"
+
+docker compose run --rm quench
+docker compose run --rm verify
+```
+
+After the second pass:
+- `Tenant_B` picks up the NCCI.
+- `Tenant_A` is **left alone** — the index already matches the declared shape, so SchemaSmith's state-based engine doesn't re-create it.
+- `Tenant_C` continues to wait.
+
+That's the rollout discipline: one tenant per window, the same package every time, no per-tenant migration files growing in your repo.
+
+## Why this matters
+
+Multi-tenant SQL Server footprints (eighty-seven tenant databases on one instance — same name, same shape, multiplied by tenant count) hit a problem unique to scale: a single heavy DDL operation that takes hours per table can't be deployed everywhere in one maintenance window. The conventional fix is a hand-maintained tenant list and a wrapper script that reads it; the rollout-state tracking lives in a spreadsheet or a wiki page or a comment block in the deploy runbook.
+
+With SchemaSmith's `ShouldApplyExpression`, the rollout state lives **in the database itself**, evaluated by SQL Server at deploy time. The DBA flips a row, the deployment picks up the change. The schema package doesn't grow by one file per tenant. The CI script doesn't grow at all.
+
+The "already-indexed" guardrail you might expect to write next to that — `AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'NCCI_OrderHistory_Analytics' AND type_desc = 'NONCLUSTERED COLUMNSTORE')` — is **implicit** in SchemaSmith's state-based engine. Once the index matches the declared shape, no re-build fires; you don't need to write that predicate yourself.
+
+## Cleanup
+
+```bash
+docker compose down --volumes
+```
+
+## Related
+
+- Article: *The Production Server That Can't Be Upgraded — and the Deployment Pipeline That Has to Live With It* (LinkedIn, 2026-06-11)
+- Sister demos:
+  - [`../PostgreSQL-VersionGate`](../PostgreSQL-VersionGate) — version-gating a virtual generated column on PG18+
+  - [`../MySQL-VersionGate`](../MySQL-VersionGate) — version-gating a `VECTOR` column on MySQL 9+

--- a/Demos/Conditional/SqlServer-RollingRollout/bootstrap/init-tenants.sql
+++ b/Demos/Conditional/SqlServer-RollingRollout/bootstrap/init-tenants.sql
@@ -1,0 +1,43 @@
+-- Bootstrap the demo: three tenant databases, each with a RolloutControl row.
+-- This simulates the "DBA flips a row from Pending to Ready" surface that
+-- governs whether the heavy NCCI build runs in this maintenance window.
+--
+-- Demo initial state:
+--   Tenant_A: RolloutControl row in 'Ready'   -> SchemaQuench will build the NCCI
+--   Tenant_B: RolloutControl row in 'Pending' -> SchemaQuench will skip the NCCI
+--   Tenant_C: RolloutControl row in 'Pending' -> SchemaQuench will skip the NCCI
+
+IF DB_ID('Tenant_A') IS NULL CREATE DATABASE Tenant_A;
+IF DB_ID('Tenant_B') IS NULL CREATE DATABASE Tenant_B;
+IF DB_ID('Tenant_C') IS NULL CREATE DATABASE Tenant_C;
+GO
+
+USE Tenant_A;
+IF OBJECT_ID('dbo.RolloutControl') IS NULL
+  CREATE TABLE dbo.RolloutControl (
+    feature VARCHAR(64) NOT NULL PRIMARY KEY,
+    status  VARCHAR(16) NOT NULL
+  );
+IF NOT EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore')
+  INSERT INTO dbo.RolloutControl(feature, status) VALUES ('OrderHistoryColumnstore', 'Ready');
+GO
+
+USE Tenant_B;
+IF OBJECT_ID('dbo.RolloutControl') IS NULL
+  CREATE TABLE dbo.RolloutControl (
+    feature VARCHAR(64) NOT NULL PRIMARY KEY,
+    status  VARCHAR(16) NOT NULL
+  );
+IF NOT EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore')
+  INSERT INTO dbo.RolloutControl(feature, status) VALUES ('OrderHistoryColumnstore', 'Pending');
+GO
+
+USE Tenant_C;
+IF OBJECT_ID('dbo.RolloutControl') IS NULL
+  CREATE TABLE dbo.RolloutControl (
+    feature VARCHAR(64) NOT NULL PRIMARY KEY,
+    status  VARCHAR(16) NOT NULL
+  );
+IF NOT EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore')
+  INSERT INTO dbo.RolloutControl(feature, status) VALUES ('OrderHistoryColumnstore', 'Pending');
+GO

--- a/Demos/Conditional/SqlServer-RollingRollout/docker-compose.yml
+++ b/Demos/Conditional/SqlServer-RollingRollout/docker-compose.yml
@@ -1,0 +1,97 @@
+name: schemasmith-conditional-sqlserver-demo
+
+# Conditional deployment demo: same schema package deploys against three tenant
+# databases (Tenant_A, Tenant_B, Tenant_C) on one SQL Server 2022 instance. A
+# nonclustered columnstore index on OrderHistory is gated by EXISTS-against-
+# RolloutControl. The initial state has Tenant_A approved ('Ready') and Tenants
+# B and C waiting ('Pending'). One quench run: only Tenant_A picks up the heavy
+# DDL. Flip another tenant's row to 'Ready' and re-run to roll the index out to
+# the next tenant in a later maintenance window.
+
+services:
+  demoserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+      MSSQL_PID: Developer
+    healthcheck:
+      test:
+        - "CMD"
+        - "/opt/mssql-tools18/bin/sqlcmd"
+        - "-S"
+        - "localhost"
+        - "-U"
+        - "sa"
+        - "-P"
+        - "${MSSQL_SA_PASSWORD}"
+        - "-C"
+        - "-Q"
+        - "SELECT 1"
+      interval: 5s
+      timeout: 10s
+      retries: 30
+    ports:
+      - "1444:1433"
+
+  bootstrap:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        /opt/mssql-tools18/bin/sqlcmd -S demoserver -U sa -P "${MSSQL_SA_PASSWORD}" -C -i /bootstrap/init-tenants.sql
+    volumes:
+      - ./bootstrap:/bootstrap
+    depends_on:
+      demoserver:
+        condition: service_healthy
+
+  quench:
+    build:
+      context: ../../../SchemaQuench
+      dockerfile: Dockerfile.release
+    environment:
+      - SmithySettings_Target__Server=demoserver
+      - SmithySettings_Target__User=sa
+      - SmithySettings_Target__Password=${MSSQL_SA_PASSWORD}
+      - SmithySettings_Target__ConnectionProperties__TrustServerCertificate=True
+      - SmithySettings_SchemaPackagePath=/metadata
+    volumes:
+      - ./Package:/metadata
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+
+  verify:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        echo
+        echo '=================================================================='
+        echo '  Verification: same schema package, three tenant databases,'
+        echo '  one rolling rollout pass'
+        echo '=================================================================='
+        echo
+        for TENANT in Tenant_A Tenant_B Tenant_C; do
+          echo "--- $$TENANT ---"
+          /opt/mssql-tools18/bin/sqlcmd -S demoserver -U sa -P "${MSSQL_SA_PASSWORD}" -C -d $$TENANT -Q \
+            "SELECT feature, status FROM dbo.RolloutControl;
+             SELECT name AS index_name, type_desc FROM sys.indexes WHERE object_id = OBJECT_ID('dbo.OrderHistory');"
+        done
+        echo
+        echo 'Single schema package. Three tenant databases. One rollout pass.'
+        echo 'Only Tenant_A (RolloutControl Ready) picked up the NCCI.'
+        echo 'Tenants B and C are intact and waiting for their own window.'
+        echo
+        echo 'To roll the NCCI to the next tenant:'
+        echo '  docker compose exec demoserver /opt/mssql-tools18/bin/sqlcmd \\'
+        echo '    -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -C -d Tenant_B -Q \\'
+        echo '    "UPDATE dbo.RolloutControl SET status = '"'"'Ready'"'"' WHERE feature = '"'"'OrderHistoryColumnstore'"'"';"'
+        echo '  docker compose run --rm quench'
+        echo
+    depends_on:
+      quench:
+        condition: service_completed_successfully

--- a/Demos/Conditional/SqlServer-RollingRollout/run-demo.cmd
+++ b/Demos/Conditional/SqlServer-RollingRollout/run-demo.cmd
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\..\.."
+set "REPO_ROOT=%CD%"
+popd
+
+echo Publishing SchemaQuench...
+call "%REPO_ROOT%\build-schemaquench.cmd"
+if errorlevel 1 exit /b %errorlevel%
+
+echo Starting SQL Server conditional-deployment demo...
+cd /d "%SCRIPT_DIR%"
+
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/Conditional/SqlServer-RollingRollout/run-demo.sh
+++ b/Demos/Conditional/SqlServer-RollingRollout/run-demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../.."
+
+echo "Publishing SchemaQuench..."
+"$REPO_ROOT/build-schemaquench.sh"
+
+echo "Starting SQL Server conditional-deployment demo..."
+cd "$SCRIPT_DIR"
+
+docker compose up --build --abort-on-container-exit verify

--- a/Demos/README.md
+++ b/Demos/README.md
@@ -11,6 +11,16 @@ Demo database schema packages for SQL Server, PostgreSQL, and MySQL, deployed by
 | Northwind | Done | Done | Done |
 | Sakila | Done | Done | Done |
 
+## Conditional Deployment Demos
+
+Demonstrations of `ShouldApplyExpression` (conditional deployment) on real engine pairs, supporting the *Production Server That Can't Be Upgraded* article (LinkedIn, 2026-06-11). See [`Conditional/`](Conditional/) for the three demos:
+
+- [`Conditional/PostgreSQL-VersionGate`](Conditional/PostgreSQL-VersionGate) — PG15 ↔ PG18, gating a virtual generated column on PG18+
+- [`Conditional/SqlServer-RollingRollout`](Conditional/SqlServer-RollingRollout) — SQL Server 2022 × 3 tenant databases, rolling out a nonclustered columnstore index one tenant per maintenance window via a `RolloutControl` table
+- [`Conditional/MySQL-VersionGate`](Conditional/MySQL-VersionGate) — MySQL 8.0 ↔ MySQL 9, gating a `VECTOR(384)` column on MySQL 9+
+
+These demos use a different docker layout than the products above (engine pairs rather than a single instance) and live in `Conditional/` rather than per-platform subdirectories.
+
 ## Quick Start
 
 Choose a platform and run the matching launcher.

--- a/SchemaQuench/DatabaseQuench.cs
+++ b/SchemaQuench/DatabaseQuench.cs
@@ -190,9 +190,23 @@ public class DatabaseQuench
                 }
 
                 // Step: Missing tables and columns
+                // Intentionally NOT wrapped in `_checkpointing.Track` — this step parses the
+                // table JSON into session-scoped temp tables (`#Tables` on SQL Server,
+                // `temp_tables` on PG, `_SchemaSmith_Tables` on MySQL) before delegating to
+                // `MissingTableAndColumnQuench`. The temp tables are consumed by the next two
+                // tracked steps (`ModifiedTables`, `IndexesAndConstraints`); they DON'T survive
+                // across connections, so on resume the next session has no temp state.
+                // The action itself is database-idempotent (the engine procs add missing
+                // tables/columns and no-op when they already exist), so always-running it on
+                // resume is safe and cheap. Skip-on-resume would fire `Invalid object name
+                // '#Tables'` (SQL Server) / `relation "temp_tables" does not exist` (PG) on
+                // the next tracked step. MySQL's `QuenchModifiedTables` and
+                // `QuenchIndexesAndConstraints` already defend against the missing-temp-tables
+                // case via `MySqlTempTablesExist` + `ParseMySqlTableJson` re-parse; lifting the
+                // Track wrapper here is the equivalent defense for SQL Server / PG.
                 if (!_template.IndexOnlyTableQuenches && _updateTables)
                 {
-                    _checkpointing.Track(DbScope, "MissingTablesAndColumns", () => QuenchMissingTablesAndColumns(effectiveTableCmd));
+                    QuenchMissingTablesAndColumns(effectiveTableCmd);
                 }
 
                 if (!IsWhatIf)

--- a/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/CheckpointIntegrationTests.cs
+++ b/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/CheckpointIntegrationTests.cs
@@ -163,6 +163,72 @@ KindleForge
     }
 
     [Test]
+    public void ShouldResumeSuccessfullyWhenMissingTablesAndColumnsAlreadyCheckpointed()
+    {
+        // Regression test for the checkpoint-resume bug surfaced 2026-06-01: when a prior run
+        // checkpointed `MissingTablesAndColumns` as complete and errored later (or simply went
+        // through full success and is re-running), the next run on a fresh connection found
+        // the step marked done in the checkpoint and skipped re-parsing the table JSON. The
+        // downstream tracked steps (`ModifiedTables`, `IndexesAndConstraints`) then crashed
+        // with `Invalid object name '#Tables'` because the session-scoped temp tables didn't
+        // exist on the new connection. Fix: `MissingTablesAndColumns` is no longer wrapped in
+        // `_checkpointing.Track` — it always runs on every quench (database-idempotent, primes
+        // session state). MySQL has had the equivalent defense (`MySqlTempTablesExist` +
+        // `ParseMySqlTableJson` re-parse) inside `QuenchModifiedTables` /
+        // `QuenchIndexesAndConstraints` from the start.
+        lock (FactoryContainer.SharedLockObject)
+        {
+            SetupSharedMocks();
+
+            FactoryContainer.Resolve<IConfigurationRoot>()["SchemaPackagePath"] = TestHelper.GetTestProductPath("SqlServer", "ValidProduct");
+            FactoryContainer.Resolve<IConfigurationRoot>()["CheckpointDirectory"] = _checkpointDir;
+
+            var product = Product.Load();
+            // Pre-write a database checkpoint that claims MissingTablesAndColumns is complete.
+            // Pre-fix, this would cause the next run's `ModifiedTables` step to crash on
+            // `Invalid object name '#Tables'`.
+            var dbCheckpointContent = $@"# SchemaQuench Database Checkpoint
+# Product: {product.Name}
+# Template: Main
+# Server: {_server}
+# Database: {_mainDb}
+# Started: {DateTime.Now:yyyy-MM-dd HH:mm:ss}
+
+[Completed Steps]
+KindleForge
+MissingTablesAndColumns
+
+[Before Scripts]
+
+[Object Scripts]
+
+[After Tables Object Scripts]
+
+[Between Tables And Keys Scripts]
+
+[After Table Scripts]
+
+[Table Data Scripts]
+
+[After Scripts]
+";
+            var dbCheckpointPath = Path.Combine(_checkpointDir,
+                $"{FileNameEncoder.Encode(product.Name)}.{FileNameEncoder.Encode("Main")}.{FileNameEncoder.Encode(_server)}.{FileNameEncoder.Encode(_mainDb)}.checkpoint");
+            File.WriteAllText(dbCheckpointPath, dbCheckpointContent);
+
+            RunSchemaQuench();
+
+            // Assert the deploy completed without the `Invalid object name '#Tables'` crash.
+            _errorLog.DidNotReceive().Error(Arg.Is<string>(s => s != null && s.Contains("Invalid object name '#Tables'")));
+            _errorLog.DidNotReceive().Error(Arg.Is<string>(s => s != null && s.Contains("Invalid object name '#Tables'")), Arg.Any<Exception>());
+
+            LogFactory.Clear();
+            FactoryContainer.Unregister<IEnvironment>();
+            FactoryContainer.Unregister<Schema.Checkpointing.ICheckpointing>();
+        }
+    }
+
+    [Test]
     public void ShouldPreserveCheckpointOnFailure()
     {
         // Verifies cleanup is skipped when a quench fails. Pre-writes a representative


### PR DESCRIPTION
## Summary

Two pieces of work on one branch off `main`, supporting the 2026-06-11 LinkedIn article:

1. **Checkpoint-resume fix** for SQL Server and PostgreSQL: `MissingTablesAndColumns` was wrapped in `_checkpointing.Track` and skipped on resume, leaving the session-scoped parser temp tables empty when downstream tracked steps tried to read them. MySQL had the equivalent defense from the start (`MySqlTempTablesExist` + `ParseMySqlTableJson` re-parse inside the downstream Quench methods); SQL Server and PG didn't.
2. **Three runnable conditional-deployment demos** in `Demos/Conditional/` showing `ShouldApplyExpression` on real engine pairs. These are the demos the article links to.

## Checkpoint-resume fix

### Bug

When a SQL Server or PostgreSQL quench failed mid-deploy after `MissingTablesAndColumns` had checkpointed as complete, the next quench would resume, see the step marked done, skip it — and then `QuenchModifiedTables` / `QuenchIndexesAndConstraints` would crash with:

- SQL Server: `Invalid object name '#Tables'. at Line: 16`
- PostgreSQL: `relation "temp_tables" does not exist`

Same root cause: the parser populates session-scoped temp tables (`#Tables`, `temp_tables`) that don't survive a new connection. The `_checkpointing.Track` skip-on-resume mechanic treats the step as a unit of work whose completion can be skipped — but it's actually a **session-primer** whose database side-effects ARE idempotent but whose session-state side-effects don't persist.

MySQL escaped this because its `QuenchModifiedTables` and `QuenchIndexesAndConstraints` already check `MySqlTempTablesExist` and call `ParseMySqlTableJson` if the temp tables are gone (DatabaseQuench.cs:961, 1007). That's the right defense; SQL Server / PG didn't have an equivalent.

### Fix

Drop the `_checkpointing.Track` wrapper around `MissingTablesAndColumns`. The action is database-idempotent (the engine procs add MISSING tables/columns and no-op when they already exist), so always running it on every quench is safe and cheap. Inline comment captures the rationale so a future refactor doesn't silently re-wrap it.

```csharp
// Step: Missing tables and columns
// Intentionally NOT wrapped in `_checkpointing.Track` — this step parses the
// table JSON into session-scoped temp tables (`#Tables` on SQL Server,
// `temp_tables` on PG, `_SchemaSmith_Tables` on MySQL) before delegating to
// `MissingTableAndColumnQuench`. The temp tables are consumed by the next two
// tracked steps (`ModifiedTables`, `IndexesAndConstraints`); they DON'T survive
// across connections, so on resume the next session has no temp state.
// ... [full rationale in source]
if (!_template.IndexOnlyTableQuenches && _updateTables)
{
    QuenchMissingTablesAndColumns(effectiveTableCmd);
}
```

### Regression test

`SqlServer/CheckpointIntegrationTests.cs:ShouldResumeSuccessfullyWhenMissingTablesAndColumnsAlreadyCheckpointed` pre-writes a checkpoint claiming `MissingTablesAndColumns` is done and runs the quench. Pre-fix it would crash with `Invalid object name '#Tables'`; post-fix it succeeds.

All 15 checkpoint integration tests pass.

## Conditional Deployment Demos

`Demos/Conditional/` (new subdir) with three runnable demos:

| Demo | Engine pair | Gated component | Condition |
|---|---|---|---|
| `PostgreSQL-VersionGate` | PG15 ↔ PG18 | Virtual generated column on `OrderEvents.Status` | `current_setting('server_version_num')::int >= 180000` |
| `SqlServer-RollingRollout` | SQL Server 2022 × 3 tenant DBs | Nonclustered columnstore index on `OrderHistory` | `EXISTS (SELECT 1 FROM dbo.RolloutControl WHERE feature = 'OrderHistoryColumnstore' AND status = 'Ready')` |
| `MySQL-VersionGate` | MySQL 8.0 ↔ MySQL 9 | `VECTOR(384)` column on `Embeddings.Embedding` | `CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED) >= 9` |

Each demo is self-contained: schema package + `docker-compose.yml` + bash/cmd launcher + one-page README. Each launcher publishes SchemaQuench, brings up the engines, runs the deploy, and emits a verification block showing what landed where.

Sample verify output (PG):

```
--- PG15 (server_version_num < 180000): Status column SKIPPED ---
 column_name | data_type | is_generated | generation_expression
 EventId     | bigint    | NEVER        |
 OccurredAt  | timestamp with time zone | NEVER |
 Payload     | jsonb     | NEVER        |

--- PG18 (server_version_num >= 180000): Status column APPLIED ---
    attgenerated = "v" confirms the column is truly VIRTUAL
 column_name | data_type | is_generated |     generation_expression      | gen_marker
 EventId     | bigint    | NEVER        |                                |
 OccurredAt  | ...       | NEVER        |                                |
 Payload     | jsonb     | NEVER        |                                |
 Status      | text      | ALWAYS       | ("Payload" ->> 'status'::text) | v
```

All three verified end-to-end on real engine pairs during this PR (PG15+PG18, MySQL 8.0+MySQL 9, SQL Server 2022 with three tenant databases).

Two minor issues caught during verification and fixed in the demo packages:

- PG: needed to quote the column reference in the `GenerationExpression` (PG folds unquoted identifiers to lowercase, so `(Payload->>'status')` → `payload` which didn't match the case-preserved `"Payload"` column).
- MySQL: needed `--log-bin-trust-function-creators=1` on both containers so the non-SUPER demo user can install SchemaSmith's helper functions during KindleTheForge.

## Internal context

- Branch off `main` (post PR #253 merge). Both pieces of work on one branch per maintainer direction.
- `feat/schema-templates` will rebase onto the new `main` once this PR + #253 are both in.
- The article (`Community` repo: `docs/plans/2026-06-11-linkedin-conditional-deployment-draft.md`) gets a follow-up commit pointing its three `[demo URL — TBD]` placeholders at the GitHub paths under `Demos/Conditional/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
