### PR TITLE
Add Learn hands-on labs (Demos/Learn)

### DIFF
--- a/Demos/Learn/README.md
+++ b/Demos/Learn/README.md
@@ -29,11 +29,15 @@ minute and run it again — SQL Server in particular takes a little while on fir
 
 ## Connection details (throwaway — sandbox only)
 
-| Engine     | Host        | Port    | User       | Password         | Database       |
-| ---------- | ----------- | ------- | ---------- | ---------------- | -------------- |
-| SQL Server | `localhost` | `11433` | `sa`       | `Learn!Passw0rd` | created in labs |
-| PostgreSQL | `localhost` | `15432` | `postgres` | `Learn!Passw0rd` | `learn`        |
-| MySQL      | `localhost` | `13306` | `root`     | `Learn!Passw0rd` | `learn`        |
+| Engine     | Host        | Port    | User       | Password         | Database |
+| ---------- | ----------- | ------- | ---------- | ---------------- | -------- |
+| SQL Server | `localhost` | `11433` | `sa`       | `Learn!Passw0rd` | `learn`  |
+| PostgreSQL | `localhost` | `15432` | `postgres` | `Learn!Passw0rd` | `learn`  |
+| MySQL      | `localhost` | `13306` | `root`     | `Learn!Passw0rd` | `learn`  |
+
+All three engines come up with a `learn` database ready to go. PostgreSQL and MySQL create it from
+environment variables; SQL Server's image can't, so a one-shot `sqlserver-init` service creates it
+once the engine is healthy, then exits.
 
 These credentials are intentionally simple and public. The sandbox is disposable — **never reuse
 them anywhere real.** The ports are offset (`11433` / `15432` / `13306`) so the sandbox won't collide

--- a/Demos/Learn/README.md
+++ b/Demos/Learn/README.md
@@ -1,0 +1,55 @@
+# SchemaSmith Learn — lab sandbox
+
+The hands-on labs for the [Learn SchemaSmith](https://learn.schemasmith.com) course run against a
+throwaway three-engine database sandbox — SQL Server, PostgreSQL, and MySQL, all at once. Spin it
+up, work through the labs, tear it down.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) (Desktop or Engine) with Compose v2.
+
+## Start the sandbox
+
+```bash
+cd docker
+docker compose up -d
+```
+
+The first run pulls three database images — give it a few minutes.
+
+## Verify it's ready
+
+```bash
+./verify-sandbox.sh        # macOS / Linux
+.\verify-sandbox.ps1       # Windows PowerShell
+```
+
+Each engine reports `PASS` once it has finished warming up. If one says it isn't healthy yet, wait a
+minute and run it again — SQL Server in particular takes a little while on first boot.
+
+## Connection details (throwaway — sandbox only)
+
+| Engine     | Host        | Port    | User       | Password         | Database       |
+| ---------- | ----------- | ------- | ---------- | ---------------- | -------------- |
+| SQL Server | `localhost` | `11433` | `sa`       | `Learn!Passw0rd` | created in labs |
+| PostgreSQL | `localhost` | `15432` | `postgres` | `Learn!Passw0rd` | `learn`        |
+| MySQL      | `localhost` | `13306` | `root`     | `Learn!Passw0rd` | `learn`        |
+
+These credentials are intentionally simple and public. The sandbox is disposable — **never reuse
+them anywhere real.** The ports are offset (`11433` / `15432` / `13306`) so the sandbox won't collide
+with a default SQL Server, PostgreSQL, or MySQL you may already be running locally.
+
+## Tear it down
+
+```bash
+cd docker
+docker compose down -v     # -v also removes the data volumes
+```
+
+## How this relates to the other demos
+
+The per-engine demos under `Demos/SqlServer`, `Demos/PostgreSQL`, and `Demos/MySQL` stand up a full
+demo: they build the CLI and auto-deploy the sample databases. This sandbox is deliberately lighter
+— it stands up empty engines so you install the CLI yourself (Module 1) and run it by hand, the way
+you would against your own database. It reuses the same engine versions and the MySQL
+function-trust flag those demos rely on, with throwaway credentials and offset ports.

--- a/Demos/Learn/docker/docker-compose.yml
+++ b/Demos/Learn/docker/docker-compose.yml
@@ -23,6 +23,27 @@ services:
       retries: 30
       start_period: 40s
 
+  # One-shot: create the `learn` database on SQL Server so all three engines
+  # have it ready (PostgreSQL and MySQL auto-create theirs via env vars; SQL
+  # Server's image does not). Runs once after SQL Server is healthy, then exits.
+  sqlserver-init:
+    image: mcr.microsoft.com/mssql-tools
+    container_name: learn-sqlserver-init
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+    restart: "no"
+    entrypoint:
+      - bash
+      - -c
+      - |
+        for i in $$(seq 1 40); do
+          /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P 'Learn!Passw0rd' -Q "IF DB_ID('learn') IS NULL CREATE DATABASE learn" && exit 0
+          echo "waiting for SQL Server to accept the sa login... ($$i)"
+          sleep 3
+        done
+        echo "init: gave up waiting for SQL Server" >&2; exit 1
+
   postgres:
     image: postgres:16
     container_name: learn-postgres

--- a/Demos/Learn/docker/docker-compose.yml
+++ b/Demos/Learn/docker/docker-compose.yml
@@ -1,0 +1,55 @@
+name: schemasmith-learn-sandbox
+
+# A throwaway three-engine sandbox for the Learn course labs.
+# Stands up empty SQL Server, PostgreSQL, and MySQL engines; the learner
+# installs the SchemaSmith CLI and runs it against these by hand.
+# Engine versions and the MySQL function-trust flag mirror the demos under
+# Demos/{SqlServer,PostgreSQL,MySQL}; ports are offset to avoid collisions.
+
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: learn-sqlserver
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Learn!Passw0rd"
+      MSSQL_PID: "Developer"
+    ports:
+      - "11433:1433"
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q 'SQL Server is now ready for client connections' /var/opt/mssql/log/errorlog 2>/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 40s
+
+  postgres:
+    image: postgres:16
+    container_name: learn-postgres
+    environment:
+      POSTGRES_PASSWORD: "Learn!Passw0rd"
+      POSTGRES_DB: "learn"
+    ports:
+      - "15432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d learn"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  mysql:
+    image: mysql:8.0
+    container_name: learn-mysql
+    command: --log-bin-trust-function-creators=1
+    environment:
+      MYSQL_ROOT_PASSWORD: "Learn!Passw0rd"
+      MYSQL_DATABASE: "learn"
+    ports:
+      - "13306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p\"$$MYSQL_ROOT_PASSWORD\" --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 20s

--- a/Demos/Learn/docker/verify-sandbox.ps1
+++ b/Demos/Learn/docker/verify-sandbox.ps1
@@ -1,0 +1,41 @@
+# Verify the SchemaSmith Learn sandbox: wait for each engine to report healthy,
+# then run a trivial connection/query against it. Prints PASS/FAIL per engine.
+
+$ErrorActionPreference = 'Continue'
+$failed = $false
+
+function Wait-Healthy {
+    param([string]$Name, [int]$Tries = 90)
+    for ($i = 0; $i -lt $Tries; $i++) {
+        $status = (docker inspect -f '{{.State.Health.Status}}' $Name 2>$null)
+        if ($LASTEXITCODE -ne 0) { return 'missing' }
+        if ($status -eq 'healthy') { return 'healthy' }
+        Start-Sleep -Seconds 2
+    }
+    return 'timeout'
+}
+
+function Test-Engine {
+    param([string]$Label, [string]$Container, [string[]]$Query)
+    Write-Host -NoNewline ("{0,-12} " -f $Label)
+    switch (Wait-Healthy $Container) {
+        'missing' { Write-Host "FAIL (container '$Container' not found - is the sandbox up?)"; $script:failed = $true; return }
+        'timeout' { Write-Host "FAIL (never became healthy)"; $script:failed = $true; return }
+    }
+    docker exec $Container @Query *> $null
+    if ($LASTEXITCODE -eq 0) { Write-Host "PASS" } else { Write-Host "FAIL (could not run a query)"; $script:failed = $true }
+}
+
+Write-Host "Verifying the SchemaSmith Learn sandbox (this can take a minute on first start)..."
+Test-Engine "SQL Server" "learn-sqlserver" @('bash', '-c', 'exec 3<>/dev/tcp/localhost/1433')
+Test-Engine "PostgreSQL" "learn-postgres"  @('psql', '-U', 'postgres', '-d', 'learn', '-tAc', 'SELECT 1')
+Test-Engine "MySQL"      "learn-mysql"     @('mysql', '-uroot', '-pLearn!Passw0rd', '-N', '-e', 'SELECT 1')
+
+Write-Host ""
+if (-not $failed) {
+    Write-Host "All three engines are ready."
+    exit 0
+} else {
+    Write-Host "One or more engines failed. Try again in a minute, or check 'docker compose logs'."
+    exit 1
+}

--- a/Demos/Learn/docker/verify-sandbox.sh
+++ b/Demos/Learn/docker/verify-sandbox.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify the SchemaSmith Learn sandbox: wait for each engine to report healthy,
+# then run a trivial connection/query against it. Prints PASS/FAIL per engine.
+set -u
+
+fail=0
+
+wait_healthy() {
+  local name="$1" tries=90
+  for ((i = 1; i <= tries; i++)); do
+    local status
+    status="$(docker inspect -f '{{.State.Health.Status}}' "$name" 2>/dev/null || echo missing)"
+    [ "$status" = "healthy" ] && return 0
+    [ "$status" = "missing" ] && return 2
+    sleep 2
+  done
+  return 1
+}
+
+check() {
+  local label="$1" container="$2"
+  shift 2
+  printf '%-12s ' "$label"
+  case "$(wait_healthy "$container"; echo $?)" in
+    *2) echo "FAIL (container '$container' not found — is the sandbox up?)"; fail=1; return ;;
+    *1) echo "FAIL (never became healthy)"; fail=1; return ;;
+  esac
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS"
+  else
+    echo "FAIL (could not run a query)"
+    fail=1
+  fi
+}
+
+echo "Verifying the SchemaSmith Learn sandbox (this can take a minute on first start)..."
+check "SQL Server" learn-sqlserver docker exec learn-sqlserver bash -c 'exec 3<>/dev/tcp/localhost/1433'
+check "PostgreSQL" learn-postgres  docker exec learn-postgres  psql -U postgres -d learn -tAc 'SELECT 1'
+check "MySQL"      learn-mysql     docker exec learn-mysql      mysql -uroot -pLearn!Passw0rd -N -e 'SELECT 1'
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "All three engines are ready."
+  exit 0
+else
+  echo "One or more engines failed. Try again in a minute, or check 'docker compose logs'."
+  exit 1
+fi

--- a/Demos/Learn/module-01/README.md
+++ b/Demos/Learn/module-01/README.md
@@ -1,0 +1,65 @@
+# Module 1 — Install & connect (lab)
+
+Goal: get the SchemaSmith CLI installed and prove it connects to each sandbox engine by
+**kindling the forge** — connecting and installing SchemaSmith's helper routines into a target
+database. You'll run a tiny starter package that has no tables yet; Module 2 picks up the same
+package and adds your first table.
+
+## Before you start
+
+- **Install the CLI.** See the [Installation guide](https://github.com/Schema-Smith/SchemaSmith/blob/main/docs/end-user/guide/installation.md) — `choco install schemasmith` on Windows, or `curl -fsSL https://raw.githubusercontent.com/Schema-Smith/SchemaSmith/main/packaging/install/install.sh | sh` on Linux/macOS.
+- **Start the sandbox.** From [`Demos/Learn/docker`](../docker), run `docker compose up -d` and confirm all three engines report `PASS` with `./verify-sandbox.sh` (or `verify-sandbox.ps1`). The sandbox provisions a `learn` database on SQL Server, PostgreSQL, and MySQL.
+
+## Step 1: Confirm the install
+
+```bash
+schemaquench --version
+```
+
+Expected:
+
+```
+SchemaQuench - Version: 2.0.0.0
+```
+
+If the command isn't found, the CLI isn't on your PATH — revisit the install guide.
+
+## Step 2: Connect and kindle each engine
+
+Each engine has its own folder with a ready-to-run settings file and a minimal package
+(`Package/`) whose template targets the sandbox's `learn` database. From this directory:
+
+```bash
+cd sqlserver    # or: postgres   |   mysql
+schemaquench --ConfigFile:connect.settings.json
+```
+
+Expected (engine name and host vary):
+
+```
+localhost,11433 (…) connection succeeded
+Validate Server
+Quenching Template: Main
+Locate Databases To Quench
+[localhost,11433].[learn] Begin Quench
+[localhost,11433].[learn]   Kindling the forge
+[localhost,11433].[learn] Successfully Quenched
+Completed quench of LearnConnect
+```
+
+That's the proof: SchemaQuench connected, validated the server, found the `learn` database, and
+kindled the forge. There are no tables in the package yet, so nothing else is deployed.
+
+Run the other two engine folders the same way. Same flow, different connection details:
+
+| Engine     | Folder       | Server (in `connect.settings.json`) | User       |
+| ---------- | ------------ | ----------------------------------- | ---------- |
+| SQL Server | `sqlserver/` | `localhost,11433`                   | `sa`       |
+| PostgreSQL | `postgres/`  | `localhost` + port `15432`          | `postgres` |
+| MySQL      | `mysql/`     | `localhost` + port `13306`          | `root`     |
+
+## What you just proved
+
+Two things have to be true before SchemaQuench can deploy: the CLI is **installed and on your
+PATH**, and it has a **working connection** (host, port, credentials) to the target. You've now
+confirmed both on all three engines — and kindled a forge ready for Module 2.

--- a/Demos/Learn/module-01/mysql/Package/Product.json
+++ b/Demos/Learn/module-01/mysql/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-01/mysql/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-01/mysql/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-01/mysql/connect.settings.json
+++ b/Demos/Learn/module-01/mysql/connect.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-01/postgres/Package/Product.json
+++ b/Demos/Learn/module-01/postgres/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-01/postgres/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-01/postgres/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-01/postgres/connect.settings.json
+++ b/Demos/Learn/module-01/postgres/connect.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-01/sqlserver/Package/Product.json
+++ b/Demos/Learn/module-01/sqlserver/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-01/sqlserver/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-01/sqlserver/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-01/sqlserver/connect.settings.json
+++ b/Demos/Learn/module-01/sqlserver/connect.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/README.md
+++ b/Demos/Learn/module-02/README.md
@@ -1,0 +1,90 @@
+# Module 2 — Your first schema package (lab)
+
+Goal: declare a table in a schema package and deploy it with SchemaQuench — then run the exact same
+command again and watch nothing happen. That no-op is the whole point of state-based deployment.
+
+You'll work from the same package you kindled in Module 1. Each engine folder has a `starter/`
+(the package with no tables yet) and a `solution/` (the finished package to compare against).
+
+## Before you start
+
+- The [sandbox](../docker) is up (`docker compose up -d`) and you completed [Module 1](../module-01) (the forge is kindled on `learn`).
+- The CLI is on your PATH (`schemaquench --version`).
+
+## Step 1: Look at the starter
+
+Pick an engine and open its `starter/Package/`:
+
+```
+starter/Package/
+  Product.json                       # Platform + template order
+  Templates/Main/Template.json       # targets the `learn` database
+```
+
+No tables yet. Let's add one.
+
+## Step 2: Declare a table
+
+Create a table file under `starter/Package/Templates/Main/Tables/`. On **SQL Server**, make
+`dbo.Widget.json`:
+
+```json
+{
+  "Schema": "dbo",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "NVARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PK_Widget", "PrimaryKey": true, "Clustered": true, "IndexColumns": "WidgetId" }
+  ]
+}
+```
+
+The other two engines are the same shape with small dialect differences — the exact files are in each
+engine's `solution/Package/.../Tables/`:
+
+| Engine     | File name            | Differences from above |
+| ---------- | -------------------- | ---------------------- |
+| SQL Server | `dbo.Widget.json`    | `NVARCHAR`, clustered PK named `PK_Widget` |
+| PostgreSQL | `public.Widget.json` | `Schema: public`, `VARCHAR`, PK named `pk_widget` |
+| MySQL      | `Widget.json`        | no `Schema`, `VARCHAR`, PK index **must** be named `PRIMARY` |
+
+## Step 3: Deploy it
+
+```bash
+cd <engine>/starter
+schemaquench --ConfigFile:deploy.settings.json
+```
+
+Expected (SQL Server shown; the wording varies slightly per engine):
+
+```
+[localhost,11433].[learn] Begin Quench
+[localhost,11433].[learn]         Adding new table [dbo].[Widget]
+[localhost,11433].[learn]         Creating constraint [dbo].[Widget].[PK_Widget]
+[localhost,11433].[learn] Successfully Quenched
+Completed quench of LearnConnect
+```
+
+PostgreSQL says `Create new table public.Widget`; MySQL says ``Create table `Widget` ``.
+
+## Step 4: Prove it's there
+
+```bash
+# SQL Server (from a SQL client): SELECT name FROM sys.tables WHERE name = 'Widget';
+docker exec learn-postgres psql -U postgres -d learn -tAc "SELECT to_regclass('public.\"Widget\"')"
+docker exec learn-mysql mysql -uroot -pLearn!Passw0rd -N -e "SELECT table_name FROM information_schema.tables WHERE table_schema='learn' AND table_name='Widget'"
+```
+
+## Step 5: Run it again — the "aha"
+
+```bash
+schemaquench --ConfigFile:deploy.settings.json
+```
+
+This time there's **no** `Adding new table` line. The declared state already matches the database, so
+SchemaQuench computes a difference of zero and changes nothing. That's idempotency: the same package
+applied twice lands in the same place. Compare your work against `solution/` if anything differs.

--- a/Demos/Learn/module-02/mysql/solution/Package/Product.json
+++ b/Demos/Learn/module-02/mysql/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-02/mysql/solution/Package/Templates/Main/Tables/Widget.json
+++ b/Demos/Learn/module-02/mysql/solution/Package/Templates/Main/Tables/Widget.json
@@ -1,0 +1,11 @@
+{
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PRIMARY", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-02/mysql/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/mysql/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/mysql/solution/deploy.settings.json
+++ b/Demos/Learn/module-02/mysql/solution/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/mysql/starter/Package/Product.json
+++ b/Demos/Learn/module-02/mysql/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-02/mysql/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/mysql/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/mysql/starter/deploy.settings.json
+++ b/Demos/Learn/module-02/mysql/starter/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/postgres/solution/Package/Product.json
+++ b/Demos/Learn/module-02/postgres/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-02/postgres/solution/Package/Templates/Main/Tables/public.Widget.json
+++ b/Demos/Learn/module-02/postgres/solution/Package/Templates/Main/Tables/public.Widget.json
@@ -1,0 +1,12 @@
+{
+  "Schema": "public",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "pk_widget", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-02/postgres/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/postgres/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/postgres/solution/deploy.settings.json
+++ b/Demos/Learn/module-02/postgres/solution/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/postgres/starter/Package/Product.json
+++ b/Demos/Learn/module-02/postgres/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-02/postgres/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/postgres/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/postgres/starter/deploy.settings.json
+++ b/Demos/Learn/module-02/postgres/starter/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/sqlserver/solution/Package/Product.json
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-02/sqlserver/solution/Package/Templates/Main/Tables/dbo.Widget.json
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/Templates/Main/Tables/dbo.Widget.json
@@ -1,0 +1,12 @@
+{
+  "Schema": "dbo",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "NVARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PK_Widget", "PrimaryKey": true, "Clustered": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-02/sqlserver/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/sqlserver/solution/deploy.settings.json
+++ b/Demos/Learn/module-02/sqlserver/solution/deploy.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-02/sqlserver/starter/Package/Product.json
+++ b/Demos/Learn/module-02/sqlserver/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-02/sqlserver/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-02/sqlserver/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-02/sqlserver/starter/deploy.settings.json
+++ b/Demos/Learn/module-02/sqlserver/starter/deploy.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/README.md
+++ b/Demos/Learn/module-03/README.md
@@ -61,11 +61,12 @@ schemaquench --ConfigFile:whatif.settings.json
 Expected (SQL Server shown):
 
 ```
-[localhost,11433].[learn]   [WhatIf] Quenching modified tables
 [localhost,11433].[learn]       ALTER TABLE [dbo].[Widget] ADD [Price] DECIMAL(10,2) NULL;
 [localhost,11433].[learn]       ALTER TABLE [dbo].[Widget] ALTER COLUMN [Name] NVARCHAR(200) NOT NULL;
 [localhost,11433].[learn] Successfully Quenched
 ```
+
+(These print among the run's `[WhatIf]` marker lines; WhatIf applies none of them.)
 
 PostgreSQL prints `ADD "Price" NUMERIC(10,2)` and `ALTER COLUMN "Name" SET DATA TYPE VARCHAR(200)`;
 MySQL prints `ADD COLUMN \`Price\` DECIMAL(10,2) NULL` and `MODIFY COLUMN \`Name\` VARCHAR(200) NOT NULL`.

--- a/Demos/Learn/module-03/README.md
+++ b/Demos/Learn/module-03/README.md
@@ -1,0 +1,106 @@
+# Module 3 — Change it and redeploy (lab)
+
+Goal: evolve the `Widget` table you built in Module 2 — widen a column and add a new one — then
+**preview the exact change with WhatIf before applying it**, deploy it, and confirm SchemaSmith
+converged the existing table to your new declared state. No hand-written `ALTER`.
+
+Each engine folder has a `starter/` (the `Widget` package as Module 2 left it) and a `solution/`
+(the evolved package, plus a `whatif.settings.json` preview config). The `solution/` is what your
+edited `starter/` should look like when you're done.
+
+## Before you start
+
+- The [sandbox](../docker) is up (`docker compose up -d`) and you completed [Module 2](../module-02),
+  so the `Widget` table already exists on `learn`.
+- The CLI is on your PATH (`schemaquench --version`).
+
+> If you're starting fresh, deploy a `starter/` first to lay down the original `Widget`:
+> `cd <engine>/starter && schemaquench --ConfigFile:deploy.settings.json`.
+
+## Step 1: Make the change
+
+Open your table file under `<engine>/starter/Package/Templates/Main/Tables/` and edit two things —
+widen `Name` from 100 to 200, and add a nullable `Price` column. On **SQL Server** (`dbo.Widget.json`):
+
+```json
+{
+  "Schema": "dbo",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "NVARCHAR(200)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true },
+    { "Name": "Price", "DataType": "DECIMAL(10,2)", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PK_Widget", "PrimaryKey": true, "Clustered": true, "IndexColumns": "WidgetId" }
+  ]
+}
+```
+
+The other two engines are the same edit with their own type names — the finished files are in each
+engine's `solution/Package/.../Tables/`:
+
+| Engine     | File name            | Type names                                          |
+| ---------- | -------------------- | --------------------------------------------------- |
+| SQL Server | `dbo.Widget.json`    | `NVARCHAR(200)`, `DECIMAL(10,2)`                    |
+| PostgreSQL | `public.Widget.json` | `VARCHAR(200)`, `DECIMAL(10,2)` (reported `NUMERIC`) |
+| MySQL      | `Widget.json`        | `VARCHAR(200)`, `DECIMAL(10,2)`                     |
+
+## Step 2: Preview with WhatIf
+
+The `solution/` folder ships a `whatif.settings.json` — identical to `deploy.settings.json` but with
+`"WhatIfONLY": true`. It computes the difference and prints the SQL it *would* run, without applying
+anything:
+
+```bash
+cd <engine>/solution
+schemaquench --ConfigFile:whatif.settings.json
+```
+
+Expected (SQL Server shown):
+
+```
+[localhost,11433].[learn]   [WhatIf] Quenching modified tables
+[localhost,11433].[learn]       ALTER TABLE [dbo].[Widget] ADD [Price] DECIMAL(10,2) NULL;
+[localhost,11433].[learn]       ALTER TABLE [dbo].[Widget] ALTER COLUMN [Name] NVARCHAR(200) NOT NULL;
+[localhost,11433].[learn] Successfully Quenched
+```
+
+PostgreSQL prints `ADD "Price" NUMERIC(10,2)` and `ALTER COLUMN "Name" SET DATA TYPE VARCHAR(200)`;
+MySQL prints `ADD COLUMN \`Price\` DECIMAL(10,2) NULL` and `MODIFY COLUMN \`Name\` VARCHAR(200) NOT NULL`.
+
+## Step 3: Confirm WhatIf changed nothing
+
+The preview is read-only. The table is still in its Module 2 shape:
+
+```bash
+# SQL Server (from a SQL client): in the `learn` DB —
+#   SELECT name, max_length FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Widget');
+docker exec learn-postgres psql -U postgres -d learn -c "SELECT column_name, data_type, character_maximum_length FROM information_schema.columns WHERE table_schema='public' AND table_name='Widget' ORDER BY ordinal_position"
+docker exec learn-mysql mysql -uroot -pLearn!Passw0rd -N -e "SELECT column_name, column_type FROM information_schema.columns WHERE table_schema='learn' AND table_name='Widget' ORDER BY ordinal_position"
+```
+
+`Name` is still 100, and there's no `Price` yet — WhatIf looked but didn't touch.
+
+## Step 4: Deploy the change
+
+```bash
+schemaquench --ConfigFile:deploy.settings.json
+```
+
+```
+[localhost,11433].[learn]         Adding 1 new columns to [dbo].[Widget]
+[localhost,11433].[learn]         Altering Column [dbo].[Widget].[Name]
+[localhost,11433].[learn] Successfully Quenched
+Completed quench of LearnConnect
+```
+
+Exactly the two changes WhatIf promised.
+
+## Step 5: Prove it converged
+
+Re-run the catalog query from Step 3 — now `Name` is 200 and `Price` is `DECIMAL(10,2)` / `NUMERIC(10,2)`,
+nullable. The primary key never moved. Run `schemaquench --ConfigFile:deploy.settings.json` once more and
+nothing happens: the declared state matches the database, so the difference is zero. Compare your edited
+`starter/` against `solution/` if anything differs.

--- a/Demos/Learn/module-03/mysql/solution/Package/Product.json
+++ b/Demos/Learn/module-03/mysql/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-03/mysql/solution/Package/Templates/Main/Tables/Widget.json
+++ b/Demos/Learn/module-03/mysql/solution/Package/Templates/Main/Tables/Widget.json
@@ -1,0 +1,12 @@
+{
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(200)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true },
+    { "Name": "Price", "DataType": "DECIMAL(10,2)", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PRIMARY", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/mysql/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/mysql/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/mysql/solution/deploy.settings.json
+++ b/Demos/Learn/module-03/mysql/solution/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/mysql/solution/whatif.settings.json
+++ b/Demos/Learn/module-03/mysql/solution/whatif.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": true,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/mysql/starter/Package/Product.json
+++ b/Demos/Learn/module-03/mysql/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-03/mysql/starter/Package/Templates/Main/Tables/Widget.json
+++ b/Demos/Learn/module-03/mysql/starter/Package/Templates/Main/Tables/Widget.json
@@ -1,0 +1,11 @@
+{
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PRIMARY", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/mysql/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/mysql/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/mysql/starter/deploy.settings.json
+++ b/Demos/Learn/module-03/mysql/starter/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/postgres/solution/Package/Product.json
+++ b/Demos/Learn/module-03/postgres/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-03/postgres/solution/Package/Templates/Main/Tables/public.Widget.json
+++ b/Demos/Learn/module-03/postgres/solution/Package/Templates/Main/Tables/public.Widget.json
@@ -1,0 +1,13 @@
+{
+  "Schema": "public",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(200)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true },
+    { "Name": "Price", "DataType": "DECIMAL(10,2)", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "pk_widget", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/postgres/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/postgres/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/postgres/solution/deploy.settings.json
+++ b/Demos/Learn/module-03/postgres/solution/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/postgres/solution/whatif.settings.json
+++ b/Demos/Learn/module-03/postgres/solution/whatif.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": true,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/postgres/starter/Package/Product.json
+++ b/Demos/Learn/module-03/postgres/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-03/postgres/starter/Package/Templates/Main/Tables/public.Widget.json
+++ b/Demos/Learn/module-03/postgres/starter/Package/Templates/Main/Tables/public.Widget.json
@@ -1,0 +1,12 @@
+{
+  "Schema": "public",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "VARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "pk_widget", "PrimaryKey": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/postgres/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/postgres/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/postgres/starter/deploy.settings.json
+++ b/Demos/Learn/module-03/postgres/starter/deploy.settings.json
@@ -1,0 +1,12 @@
+{
+  "Target": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": {}
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/sqlserver/solution/Package/Product.json
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-03/sqlserver/solution/Package/Templates/Main/Tables/dbo.Widget.json
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/Templates/Main/Tables/dbo.Widget.json
@@ -1,0 +1,13 @@
+{
+  "Schema": "dbo",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "NVARCHAR(200)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true },
+    { "Name": "Price", "DataType": "DECIMAL(10,2)", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PK_Widget", "PrimaryKey": true, "Clustered": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/sqlserver/solution/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/sqlserver/solution/deploy.settings.json
+++ b/Demos/Learn/module-03/sqlserver/solution/deploy.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/sqlserver/solution/whatif.settings.json
+++ b/Demos/Learn/module-03/sqlserver/solution/whatif.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": true,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-03/sqlserver/starter/Package/Product.json
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/Product.json
@@ -1,0 +1,8 @@
+{
+  "Name": "LearnConnect",
+  "ValidationScript": "SELECT 1",
+  "TemplateOrder": ["Main"],
+  "ScriptTokens": {},
+  "ScriptFolders": [],
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-03/sqlserver/starter/Package/Templates/Main/Tables/dbo.Widget.json
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/Templates/Main/Tables/dbo.Widget.json
@@ -1,0 +1,12 @@
+{
+  "Schema": "dbo",
+  "Name": "Widget",
+  "Columns": [
+    { "Name": "WidgetId", "DataType": "BIGINT" },
+    { "Name": "Name", "DataType": "NVARCHAR(100)" },
+    { "Name": "Quantity", "DataType": "INT", "Nullable": true }
+  ],
+  "Indexes": [
+    { "Name": "PK_Widget", "PrimaryKey": true, "Clustered": true, "IndexColumns": "WidgetId" }
+  ]
+}

--- a/Demos/Learn/module-03/sqlserver/starter/Package/Templates/Main/Template.json
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/Templates/Main/Template.json
@@ -1,0 +1,5 @@
+{
+  "Name": "Main",
+  "DatabaseIdentificationScript": "SELECT name FROM sys.databases WHERE name = 'learn'",
+  "ScriptFolders": []
+}

--- a/Demos/Learn/module-03/sqlserver/starter/deploy.settings.json
+++ b/Demos/Learn/module-03/sqlserver/starter/deploy.settings.json
@@ -1,0 +1,11 @@
+{
+  "Target": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "WhatIfONLY": false,
+  "SchemaPackagePath": "./Package",
+  "KindleTheForge": true
+}

--- a/Demos/Learn/module-04/README.md
+++ b/Demos/Learn/module-04/README.md
@@ -1,0 +1,96 @@
+# Module 4 — Bring an existing database under management (lab)
+
+Goal: take a database that nobody has under source control, point **SchemaTongs** at it, and cast it
+into a schema package — tables, keys, and indexes — that you then own and manage like any other.
+
+Each engine folder has:
+- `seed.sql` — plain DDL (+ a little data) that stands up a small `chinook` music-catalog database.
+  This is **not** a SchemaSmith package; it's the "legacy" database you're bringing under management.
+- `tongs.settings.json` — the SchemaTongs config: where to connect and where to write the package.
+- `solution/` — the package SchemaTongs produces, to compare your extraction against.
+
+It's a trimmed slice of the classic Chinook schema: `Artist`, `Album`, `Track`, `Genre`,
+`MediaType`, `Playlist`, and `PlaylistTrack` (7 tables, real foreign keys).
+
+## Before you start
+
+- The [sandbox](../docker) is up (`docker compose up -d`).
+- The CLI is on your PATH (`schematongs --version`).
+
+## Step 1: Stand up the "existing" database
+
+Load `seed.sql` into the sandbox. It creates a `chinook` database and the seven tables.
+
+```bash
+# SQL Server
+docker exec -i learn-sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Learn!Passw0rd' -C < sqlserver/seed.sql
+
+# PostgreSQL  (the seed CREATEs the chinook database, then \c switches into it)
+docker exec -i learn-postgres psql -U postgres -d learn < postgres/seed.sql
+
+# MySQL
+docker exec -i learn-mysql mysql -uroot -pLearn!Passw0rd < mysql/seed.sql
+```
+
+Spot-check it's there (SQL Server shown): `SELECT name FROM chinook.sys.tables;` — seven tables, none
+of them yours yet.
+
+## Step 2: Cast it into a package
+
+From your engine folder:
+
+```bash
+cd <engine>
+schematongs --ConfigFile:tongs.settings.json
+```
+
+Expected:
+
+```
+  Cast Json for dbo.Album
+  Cast Json for dbo.Artist
+  ... (and the rest)
+
+=== Casting Summary ===
+  Tables:     7 extracted, 0 errors
+Casting Completed Successfully
+```
+
+SchemaTongs writes the package to `./Extracted`:
+
+```
+Extracted/
+  Product.json
+  Templates/Chinook/Tables/<schema>.Album.json
+  Templates/Chinook/Tables/<schema>.Artist.json
+  ... (one file per table)
+```
+
+## Step 3: See what it caught
+
+Open `Extracted/Templates/Chinook/Tables/<schema>.Album.json`. SchemaTongs didn't just record columns —
+it pulled the **primary key**, the **index** on the artist column, and the **foreign key** linking
+`Album` back to `Artist`, straight from the live catalog. Those relationships are the first thing you'd
+miss transcribing a schema by hand.
+
+Per-engine differences are cosmetic: SQL Server quotes with `[brackets]` and reports `INT IDENTITY`;
+PostgreSQL folds names to lowercase (`public.album.json`) and reports types like `int4`; MySQL quotes
+with `` `backticks` `` and records `AutoIncrement` plus the storage engine.
+
+## Step 4: Compare against the solution
+
+Your `Extracted/` package should match `solution/`. From here, it's a normal SchemaSmith package — you
+manage it exactly like the one you built in Module 2: edit a table, preview with WhatIf, and quench.
+
+## Reset
+
+To start over, drop the database and re-run the seed:
+
+```bash
+# SQL Server
+docker exec learn-sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Learn!Passw0rd' -C -Q "DROP DATABASE chinook"
+# PostgreSQL
+docker exec learn-postgres psql -U postgres -d learn -c "DROP DATABASE chinook"
+# MySQL
+docker exec learn-mysql mysql -uroot -pLearn!Passw0rd -e "DROP DATABASE chinook"
+```

--- a/Demos/Learn/module-04/mysql/seed.sql
+++ b/Demos/Learn/module-04/mysql/seed.sql
@@ -1,0 +1,79 @@
+-- Module 4 seed (MySQL): a small "existing" music-catalog database that nobody
+-- has under source control yet. Plain DDL + a little data — NOT a SchemaSmith
+-- package. You'll point SchemaTongs at it and cast it into one.
+-- A trimmed-down slice of the classic Chinook sample schema.
+
+CREATE DATABASE IF NOT EXISTS chinook;
+USE chinook;
+
+CREATE TABLE Artist (
+    ArtistId INT NOT NULL AUTO_INCREMENT,
+    Name VARCHAR(120) NULL,
+    CONSTRAINT PK_Artist PRIMARY KEY (ArtistId)
+);
+
+CREATE TABLE Genre (
+    GenreId INT NOT NULL AUTO_INCREMENT,
+    Name VARCHAR(120) NULL,
+    CONSTRAINT PK_Genre PRIMARY KEY (GenreId)
+);
+
+CREATE TABLE MediaType (
+    MediaTypeId INT NOT NULL AUTO_INCREMENT,
+    Name VARCHAR(120) NULL,
+    CONSTRAINT PK_MediaType PRIMARY KEY (MediaTypeId)
+);
+
+CREATE TABLE Album (
+    AlbumId INT NOT NULL AUTO_INCREMENT,
+    Title VARCHAR(160) NOT NULL,
+    ArtistId INT NOT NULL,
+    CONSTRAINT PK_Album PRIMARY KEY (AlbumId),
+    CONSTRAINT FK_Album_Artist FOREIGN KEY (ArtistId) REFERENCES Artist(ArtistId)
+);
+
+CREATE TABLE Track (
+    TrackId INT NOT NULL AUTO_INCREMENT,
+    Name VARCHAR(200) NOT NULL,
+    AlbumId INT NULL,
+    MediaTypeId INT NOT NULL,
+    GenreId INT NULL,
+    Composer VARCHAR(220) NULL,
+    Milliseconds INT NOT NULL,
+    UnitPrice DECIMAL(10,2) NOT NULL,
+    CONSTRAINT PK_Track PRIMARY KEY (TrackId),
+    CONSTRAINT FK_Track_Album FOREIGN KEY (AlbumId) REFERENCES Album(AlbumId),
+    CONSTRAINT FK_Track_MediaType FOREIGN KEY (MediaTypeId) REFERENCES MediaType(MediaTypeId),
+    CONSTRAINT FK_Track_Genre FOREIGN KEY (GenreId) REFERENCES Genre(GenreId)
+);
+
+CREATE TABLE Playlist (
+    PlaylistId INT NOT NULL AUTO_INCREMENT,
+    Name VARCHAR(120) NULL,
+    CONSTRAINT PK_Playlist PRIMARY KEY (PlaylistId)
+);
+
+CREATE TABLE PlaylistTrack (
+    PlaylistId INT NOT NULL,
+    TrackId INT NOT NULL,
+    CONSTRAINT PK_PlaylistTrack PRIMARY KEY (PlaylistId, TrackId),
+    CONSTRAINT FK_PlaylistTrack_Playlist FOREIGN KEY (PlaylistId) REFERENCES Playlist(PlaylistId),
+    CONSTRAINT FK_PlaylistTrack_Track FOREIGN KEY (TrackId) REFERENCES Track(TrackId)
+);
+
+INSERT INTO Genre (Name) VALUES ('Rock'), ('Jazz'), ('Metal');
+INSERT INTO MediaType (Name) VALUES ('MPEG audio file'), ('AAC audio file');
+INSERT INTO Artist (Name) VALUES ('AC/DC'), ('Accept'), ('Aerosmith'), ('Miles Davis'), ('Metallica');
+INSERT INTO Album (Title, ArtistId) VALUES
+    ('For Those About To Rock We Salute You', 1),
+    ('Balls to the Wall', 2),
+    ('Big Ones', 3),
+    ('Kind of Blue', 4),
+    ('Master of Puppets', 5);
+INSERT INTO Track (Name, AlbumId, MediaTypeId, GenreId, Composer, Milliseconds, UnitPrice) VALUES
+    ('For Those About To Rock (We Salute You)', 1, 1, 1, 'Young, Young, Johnson', 343719, 0.99),
+    ('Balls to the Wall', 2, 1, 3, NULL, 342562, 0.99),
+    ('So What', 4, 1, 2, 'Miles Davis', 562000, 0.99),
+    ('Master of Puppets', 5, 1, 3, 'Hetfield, Ulrich, Burton, Hammett', 515000, 0.99);
+INSERT INTO Playlist (Name) VALUES ('My favorites');
+INSERT INTO PlaylistTrack (PlaylistId, TrackId) VALUES (1, 1), (1, 4);

--- a/Demos/Learn/module-04/mysql/solution/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-04/mysql/solution/.json-schemas/products.mysql.schema
@@ -1,0 +1,79 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "ValidationScript": {
+      "type": "string"
+    },
+    "TemplateOrder": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "ServerToQuench": {
+            "type": "integer"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "BranchNameFile": {
+      "type": "string"
+    },
+    "BeforeBranchNameMask": {
+      "type": "string"
+    },
+    "AfterBranchNameMask": {
+      "type": "string"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "Platform": {
+      "type": "string",
+      "pattern": "Unknown|PostgreSQL|SqlServer|MySQL"
+    },
+    "MinimumVersion": {
+      "type": "string"
+    },
+    "CheckConstraintStyle": {
+      "type": "string",
+      "pattern": "ColumnLevel|TableLevel"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "ValidationScript"
+  ]
+}

--- a/Demos/Learn/module-04/mysql/solution/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-04/mysql/solution/.json-schemas/tables.mysql.schema
@@ -1,0 +1,254 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "Columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "DataType": {
+            "type": "string"
+          },
+          "Nullable": {
+            "type": "boolean"
+          },
+          "Default": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "OldName": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "DataType"
+        ]
+      }
+    },
+    "Indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "PrimaryKey": {
+            "type": "boolean"
+          },
+          "Unique": {
+            "type": "boolean"
+          },
+          "UniqueConstraint": {
+            "type": "boolean"
+          },
+          "IndexColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "IndexColumns"
+        ]
+      }
+    },
+    "ForeignKeys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Columns": {
+            "type": "string"
+          },
+          "RelatedTable": {
+            "type": "string"
+          },
+          "RelatedColumns": {
+            "type": "string"
+          },
+          "DeleteAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "UpdateAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Columns",
+          "RelatedTable",
+          "RelatedColumns"
+        ]
+      }
+    },
+    "CheckConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Expression": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Expression"
+        ]
+      }
+    },
+    "ShouldApplyExpression": {
+      "type": "string"
+    },
+    "DataDelivery": {
+      "type": "object",
+      "properties": {
+        "ContentFile": {
+          "type": "string"
+        },
+        "MergeType": {
+          "type": "string",
+          "pattern": "Insert|Insert/Update|Insert/Update/Delete"
+        },
+        "MatchColumns": {
+          "type": "string"
+        },
+        "MergeFilter": {
+          "type": "string"
+        },
+        "MergeDisableTriggers": {
+          "type": "boolean"
+        },
+        "MergeDisableRules": {
+          "type": "boolean"
+        },
+        "MergeUpdateDescendents": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "VariantName": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "OldName": {
+      "type": "string"
+    },
+    "Engine": {
+      "type": "string"
+    },
+    "RowFormat": {
+      "type": "string",
+      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+    },
+    "CharacterSet": {
+      "type": "string"
+    },
+    "Collation": {
+      "type": "string"
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "AutoIncrementValue": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "minimum": 1.0
+    },
+    "FullTextIndexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Columns": {
+            "type": "string"
+          },
+          "Parser": {
+            "type": "string"
+          },
+          "Comment": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Columns"
+        ]
+      }
+    },
+    "Extensions": {}
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name"
+  ]
+}

--- a/Demos/Learn/module-04/mysql/solution/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-04/mysql/solution/.json-schemas/templates.mysql.schema
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "DatabaseIdentificationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "IndexOnlyTableQuenches": {
+      "type": "boolean"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "UpdateFillFactor": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "Required": {
+      "type": "boolean"
+    },
+    "SkipIfReadOnly": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "DatabaseIdentificationScript"
+  ]
+}

--- a/Demos/Learn/module-04/mysql/solution/Product.json
+++ b/Demos/Learn/module-04/mysql/solution/Product.json
@@ -1,0 +1,15 @@
+{
+  "Name": "Chinook",
+  "ValidationScript": "SELECT EXISTS(SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME = '{{ChinookDb}}')",
+  "TemplateOrder": [
+    "Chinook"
+  ],
+  "ScriptTokens": {
+    "ChinookDb": "chinook"
+  },
+  "ScriptFolders": [],
+  "BranchNameFile": "{{repo_path}}/.git/HEAD",
+  "BeforeBranchNameMask": "ref: refs/heads/",
+  "AfterBranchNameMask": "",
+  "Platform": "MySQL"
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Album.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Album.json
@@ -1,0 +1,52 @@
+{
+  "Name": "`Album`",
+  "Columns": [
+    {
+      "Name": "`AlbumId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Title`",
+      "DataType": "varchar(160)",
+      "CharacterSet": "utf8mb4"
+    },
+    {
+      "Name": "`ArtistId`",
+      "DataType": "int"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "FK_Album_Artist",
+      "IndexColumns": "`ArtistId`",
+      "IndexType": "BTREE"
+    },
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`AlbumId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "FK_Album_Artist",
+      "Columns": "`ArtistId`",
+      "RelatedTable": "`Artist`",
+      "RelatedColumns": "`ArtistId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 6,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Artist.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Artist.json
@@ -1,0 +1,34 @@
+{
+  "Name": "`Artist`",
+  "Columns": [
+    {
+      "Name": "`ArtistId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Name`",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "CharacterSet": "utf8mb4"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`ArtistId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 6,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Genre.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Genre.json
@@ -1,0 +1,34 @@
+{
+  "Name": "`Genre`",
+  "Columns": [
+    {
+      "Name": "`GenreId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Name`",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "CharacterSet": "utf8mb4"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`GenreId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 4,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/MediaType.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/MediaType.json
@@ -1,0 +1,34 @@
+{
+  "Name": "`MediaType`",
+  "Columns": [
+    {
+      "Name": "`MediaTypeId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Name`",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "CharacterSet": "utf8mb4"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`MediaTypeId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 3,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Playlist.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Playlist.json
@@ -1,0 +1,34 @@
+{
+  "Name": "`Playlist`",
+  "Columns": [
+    {
+      "Name": "`PlaylistId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Name`",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "CharacterSet": "utf8mb4"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`PlaylistId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 2,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/PlaylistTrack.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/PlaylistTrack.json
@@ -1,0 +1,54 @@
+{
+  "Name": "`PlaylistTrack`",
+  "Columns": [
+    {
+      "Name": "`PlaylistId`",
+      "DataType": "int"
+    },
+    {
+      "Name": "`TrackId`",
+      "DataType": "int"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "FK_PlaylistTrack_Track",
+      "IndexColumns": "`TrackId`",
+      "IndexType": "BTREE"
+    },
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`PlaylistId`,`TrackId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "FK_PlaylistTrack_Playlist",
+      "Columns": "`PlaylistId`",
+      "RelatedTable": "`Playlist`",
+      "RelatedColumns": "`PlaylistId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    },
+    {
+      "Name": "FK_PlaylistTrack_Track",
+      "Columns": "`TrackId`",
+      "RelatedTable": "`Track`",
+      "RelatedColumns": "`TrackId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Track.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Tables/Track.json
@@ -1,0 +1,104 @@
+{
+  "Name": "`Track`",
+  "Columns": [
+    {
+      "Name": "`TrackId`",
+      "DataType": "int",
+      "AutoIncrement": true
+    },
+    {
+      "Name": "`Name`",
+      "DataType": "varchar(200)",
+      "CharacterSet": "utf8mb4"
+    },
+    {
+      "Name": "`AlbumId`",
+      "DataType": "int",
+      "Nullable": true
+    },
+    {
+      "Name": "`MediaTypeId`",
+      "DataType": "int"
+    },
+    {
+      "Name": "`GenreId`",
+      "DataType": "int",
+      "Nullable": true
+    },
+    {
+      "Name": "`Composer`",
+      "DataType": "varchar(220)",
+      "Nullable": true,
+      "CharacterSet": "utf8mb4"
+    },
+    {
+      "Name": "`Milliseconds`",
+      "DataType": "int"
+    },
+    {
+      "Name": "`UnitPrice`",
+      "DataType": "decimal(10,2)"
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "FK_Track_Album",
+      "IndexColumns": "`AlbumId`",
+      "IndexType": "BTREE"
+    },
+    {
+      "Name": "FK_Track_Genre",
+      "IndexColumns": "`GenreId`",
+      "IndexType": "BTREE"
+    },
+    {
+      "Name": "FK_Track_MediaType",
+      "IndexColumns": "`MediaTypeId`",
+      "IndexType": "BTREE"
+    },
+    {
+      "Name": "PRIMARY",
+      "PrimaryKey": true,
+      "Unique": true,
+      "UniqueConstraint": true,
+      "IndexColumns": "`TrackId`",
+      "IndexType": "BTREE"
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "FK_Track_Album",
+      "Columns": "`AlbumId`",
+      "RelatedTable": "`Album`",
+      "RelatedColumns": "`AlbumId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    },
+    {
+      "Name": "FK_Track_MediaType",
+      "Columns": "`MediaTypeId`",
+      "RelatedTable": "`MediaType`",
+      "RelatedColumns": "`MediaTypeId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    },
+    {
+      "Name": "FK_Track_Genre",
+      "Columns": "`GenreId`",
+      "RelatedTable": "`Genre`",
+      "RelatedColumns": "`GenreId`",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "Engine": "InnoDB",
+  "RowFormat": "Dynamic",
+  "CharacterSet": "utf8mb4",
+  "Collation": "utf8mb4_0900_ai_ci",
+  "AutoIncrementValue": 5,
+  "FullTextIndexes": []
+}

--- a/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Template.json
+++ b/Demos/Learn/module-04/mysql/solution/Templates/Chinook/Template.json
@@ -1,0 +1,43 @@
+{
+  "Name": "Chinook",
+  "DatabaseIdentificationScript": "SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = '{{ChinookDb}}'",
+  "ScriptFolders": [
+    {
+      "FolderPath": "Before Scripts"
+    },
+    {
+      "FolderPath": "Events",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Events"
+    },
+    {
+      "FolderPath": "Functions",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Functions"
+    },
+    {
+      "FolderPath": "Procedures",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Procedures"
+    },
+    {
+      "FolderPath": "Triggers",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Triggers"
+    },
+    {
+      "FolderPath": "Views",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Views"
+    },
+    {
+      "FolderPath": "Table Data",
+      "QuenchSlot": "TableData"
+    },
+    {
+      "FolderPath": "After Scripts",
+      "QuenchSlot": "After"
+    }
+  ],
+  "ScriptTokens": {}
+}

--- a/Demos/Learn/module-04/mysql/tongs.settings.json
+++ b/Demos/Learn/module-04/mysql/tongs.settings.json
@@ -1,0 +1,14 @@
+{
+  "Source": {
+    "Server": "localhost",
+    "Port": "13306",
+    "User": "root",
+    "Password": "Learn!Passw0rd",
+    "Database": "chinook",
+    "Platform": "MySQL",
+    "ConnectionProperties": {}
+  },
+  "Product": { "Path": "./Extracted", "Name": "Chinook" },
+  "Template": { "Name": "Chinook" },
+  "ShouldCast": { "Tables": true }
+}

--- a/Demos/Learn/module-04/postgres/seed.sql
+++ b/Demos/Learn/module-04/postgres/seed.sql
@@ -1,0 +1,70 @@
+-- Module 4 seed (PostgreSQL): a small "existing" music-catalog database that
+-- nobody has under source control yet. Plain DDL + a little data — NOT a
+-- SchemaSmith package. You'll point SchemaTongs at it and cast it into one.
+-- A trimmed-down slice of the classic Chinook sample schema.
+-- Run connected to any existing database (e.g. learn); the \c switches into chinook.
+
+CREATE DATABASE chinook;
+\c chinook
+
+CREATE TABLE artist (
+    artist_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_artist PRIMARY KEY,
+    name VARCHAR(120)
+);
+
+CREATE TABLE genre (
+    genre_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_genre PRIMARY KEY,
+    name VARCHAR(120)
+);
+
+CREATE TABLE media_type (
+    media_type_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_media_type PRIMARY KEY,
+    name VARCHAR(120)
+);
+
+CREATE TABLE album (
+    album_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_album PRIMARY KEY,
+    title VARCHAR(160) NOT NULL,
+    artist_id INT NOT NULL CONSTRAINT fk_album_artist REFERENCES artist(artist_id)
+);
+CREATE INDEX ix_album_artist_id ON album(artist_id);
+
+CREATE TABLE track (
+    track_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_track PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    album_id INT CONSTRAINT fk_track_album REFERENCES album(album_id),
+    media_type_id INT NOT NULL CONSTRAINT fk_track_media_type REFERENCES media_type(media_type_id),
+    genre_id INT CONSTRAINT fk_track_genre REFERENCES genre(genre_id),
+    composer VARCHAR(220),
+    milliseconds INT NOT NULL,
+    unit_price NUMERIC(10,2) NOT NULL
+);
+CREATE INDEX ix_track_album_id ON track(album_id);
+
+CREATE TABLE playlist (
+    playlist_id INT GENERATED ALWAYS AS IDENTITY CONSTRAINT pk_playlist PRIMARY KEY,
+    name VARCHAR(120)
+);
+
+CREATE TABLE playlist_track (
+    playlist_id INT NOT NULL CONSTRAINT fk_playlist_track_playlist REFERENCES playlist(playlist_id),
+    track_id INT NOT NULL CONSTRAINT fk_playlist_track_track REFERENCES track(track_id),
+    CONSTRAINT pk_playlist_track PRIMARY KEY (playlist_id, track_id)
+);
+
+INSERT INTO genre (name) VALUES ('Rock'), ('Jazz'), ('Metal');
+INSERT INTO media_type (name) VALUES ('MPEG audio file'), ('AAC audio file');
+INSERT INTO artist (name) VALUES ('AC/DC'), ('Accept'), ('Aerosmith'), ('Miles Davis'), ('Metallica');
+INSERT INTO album (title, artist_id) VALUES
+    ('For Those About To Rock We Salute You', 1),
+    ('Balls to the Wall', 2),
+    ('Big Ones', 3),
+    ('Kind of Blue', 4),
+    ('Master of Puppets', 5);
+INSERT INTO track (name, album_id, media_type_id, genre_id, composer, milliseconds, unit_price) VALUES
+    ('For Those About To Rock (We Salute You)', 1, 1, 1, 'Young, Young, Johnson', 343719, 0.99),
+    ('Balls to the Wall', 2, 1, 3, NULL, 342562, 0.99),
+    ('So What', 4, 1, 2, 'Miles Davis', 562000, 0.99),
+    ('Master of Puppets', 5, 1, 3, 'Hetfield, Ulrich, Burton, Hammett', 515000, 0.99);
+INSERT INTO playlist (name) VALUES ('My favorites');
+INSERT INTO playlist_track (playlist_id, track_id) VALUES (1, 1), (1, 4);

--- a/Demos/Learn/module-04/postgres/solution/.json-schemas/materializedviews.postgresql.schema
+++ b/Demos/Learn/module-04/postgres/solution/.json-schemas/materializedviews.postgresql.schema
@@ -1,0 +1,103 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "Schema": {
+      "type": "string"
+    },
+    "Definition": {
+      "type": "string"
+    },
+    "WithData": {
+      "type": "boolean"
+    },
+    "Tablespace": {
+      "type": "string"
+    },
+    "AccessMethod": {
+      "type": "string"
+    },
+    "ShouldApplyExpression": {
+      "type": "string"
+    },
+    "VariantName": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "Indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "PrimaryKey": {
+            "type": "boolean"
+          },
+          "Unique": {
+            "type": "boolean"
+          },
+          "UniqueConstraint": {
+            "type": "boolean"
+          },
+          "IndexColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "FilterExpression": {
+            "type": "string"
+          },
+          "Clustered": {
+            "type": "boolean"
+          },
+          "IncludeColumns": {
+            "type": "string"
+          },
+          "AccessMethod": {
+            "type": "string"
+          },
+          "FillFactor": {
+            "type": "integer",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "NullsNotDistinct": {
+            "type": "boolean"
+          },
+          "Deferrable": {
+            "type": "boolean"
+          },
+          "InitiallyDeferred": {
+            "type": "boolean"
+          },
+          "UpdateFillFactor": {
+            "type": "boolean"
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "IndexColumns"
+        ]
+      }
+    },
+    "Extensions": {}
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "Definition"
+  ]
+}

--- a/Demos/Learn/module-04/postgres/solution/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-04/postgres/solution/.json-schemas/products.postgresql.schema
@@ -1,0 +1,79 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "ValidationScript": {
+      "type": "string"
+    },
+    "TemplateOrder": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "ServerToQuench": {
+            "type": "integer"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "BranchNameFile": {
+      "type": "string"
+    },
+    "BeforeBranchNameMask": {
+      "type": "string"
+    },
+    "AfterBranchNameMask": {
+      "type": "string"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "Platform": {
+      "type": "string",
+      "pattern": "Unknown|PostgreSQL|SqlServer|MySQL"
+    },
+    "MinimumVersion": {
+      "type": "string"
+    },
+    "CheckConstraintStyle": {
+      "type": "string",
+      "pattern": "ColumnLevel|TableLevel"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "ValidationScript"
+  ]
+}

--- a/Demos/Learn/module-04/postgres/solution/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-04/postgres/solution/.json-schemas/tables.postgresql.schema
@@ -1,0 +1,308 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "Columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "DataType": {
+            "type": "string"
+          },
+          "Nullable": {
+            "type": "boolean"
+          },
+          "Default": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "OldName": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "DataType"
+        ]
+      }
+    },
+    "Indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "PrimaryKey": {
+            "type": "boolean"
+          },
+          "Unique": {
+            "type": "boolean"
+          },
+          "UniqueConstraint": {
+            "type": "boolean"
+          },
+          "IndexColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "IndexColumns"
+        ]
+      }
+    },
+    "ForeignKeys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Columns": {
+            "type": "string"
+          },
+          "RelatedTable": {
+            "type": "string"
+          },
+          "RelatedColumns": {
+            "type": "string"
+          },
+          "DeleteAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "UpdateAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Columns",
+          "RelatedTable",
+          "RelatedColumns"
+        ]
+      }
+    },
+    "CheckConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Expression": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Expression"
+        ]
+      }
+    },
+    "ShouldApplyExpression": {
+      "type": "string"
+    },
+    "DataDelivery": {
+      "type": "object",
+      "properties": {
+        "ContentFile": {
+          "type": "string"
+        },
+        "MergeType": {
+          "type": "string",
+          "pattern": "Insert|Insert/Update|Insert/Update/Delete"
+        },
+        "MatchColumns": {
+          "type": "string"
+        },
+        "MergeFilter": {
+          "type": "string"
+        },
+        "MergeDisableTriggers": {
+          "type": "boolean"
+        },
+        "MergeDisableRules": {
+          "type": "boolean"
+        },
+        "MergeUpdateDescendents": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "VariantName": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "OldName": {
+      "type": "string"
+    },
+    "Schema": {
+      "type": "string"
+    },
+    "Statistics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Kind": {
+            "type": "string"
+          },
+          "StatisticsColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "StatisticsColumns"
+        ]
+      }
+    },
+    "ExcludeConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "AccessMethod": {
+            "type": "string"
+          },
+          "ExcludeColumns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Column": {
+                  "type": "string"
+                },
+                "Operator": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "Column",
+                "Operator"
+              ]
+            }
+          },
+          "FilterExpression": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "Deferrable": {
+            "type": "boolean"
+          },
+          "InitiallyDeferred": {
+            "type": "boolean"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "ExcludeColumns"
+        ]
+      }
+    },
+    "RowLevelSecurity": {
+      "type": "boolean"
+    },
+    "ForceRowLevelSecurity": {
+      "type": "boolean"
+    },
+    "AccessMethod": {
+      "type": "string"
+    },
+    "PersistenceType": {
+      "type": "string"
+    },
+    "UpdateFillFactor": {
+      "type": "boolean"
+    },
+    "FillFactor": {
+      "type": "integer",
+      "minimum": 0.0,
+      "maximum": 100.0
+    },
+    "Extensions": {}
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name"
+  ]
+}

--- a/Demos/Learn/module-04/postgres/solution/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-04/postgres/solution/.json-schemas/templates.postgresql.schema
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "DatabaseIdentificationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "IndexOnlyTableQuenches": {
+      "type": "boolean"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "UpdateFillFactor": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "Required": {
+      "type": "boolean"
+    },
+    "SkipIfReadOnly": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "DatabaseIdentificationScript"
+  ]
+}

--- a/Demos/Learn/module-04/postgres/solution/Product.json
+++ b/Demos/Learn/module-04/postgres/solution/Product.json
@@ -1,0 +1,15 @@
+{
+  "Name": "Chinook",
+  "ValidationScript": "SELECT EXISTS(SELECT * FROM pg_database WHERE datname = '{{ChinookDb}}')",
+  "TemplateOrder": [
+    "Chinook"
+  ],
+  "ScriptTokens": {
+    "ChinookDb": "chinook"
+  },
+  "ScriptFolders": [],
+  "BranchNameFile": "{{repo_path}}/.git/HEAD",
+  "BeforeBranchNameMask": "ref: refs/heads/",
+  "AfterBranchNameMask": "",
+  "Platform": "PostgreSQL"
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.album.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.album.json
@@ -1,0 +1,51 @@
+{
+  "Name": "album",
+  "Columns": [
+    {
+      "Name": "album_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "artist_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "title",
+      "DataType": "varchar(160)",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "ix_album_artist_id",
+      "IndexColumns": "artist_id",
+      "ShouldApplyExpression": ""
+    },
+    {
+      "Name": "pk_album",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "album_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "fk_album_artist",
+      "Columns": "artist_id",
+      "RelatedTable": "artist",
+      "RelatedColumns": "artist_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.artist.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.artist.json
@@ -1,0 +1,31 @@
+{
+  "Name": "artist",
+  "Columns": [
+    {
+      "Name": "artist_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "name",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_artist",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "artist_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.genre.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.genre.json
@@ -1,0 +1,31 @@
+{
+  "Name": "genre",
+  "Columns": [
+    {
+      "Name": "genre_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "name",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_genre",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "genre_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.media_type.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.media_type.json
@@ -1,0 +1,31 @@
+{
+  "Name": "media_type",
+  "Columns": [
+    {
+      "Name": "media_type_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "name",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_media_type",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "media_type_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.playlist.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.playlist.json
@@ -1,0 +1,31 @@
+{
+  "Name": "playlist",
+  "Columns": [
+    {
+      "Name": "name",
+      "DataType": "varchar(120)",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "playlist_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_playlist",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "playlist_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.playlist_track.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.playlist_track.json
@@ -1,0 +1,49 @@
+{
+  "Name": "playlist_track",
+  "Columns": [
+    {
+      "Name": "playlist_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "track_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "pk_playlist_track",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "playlist_id,track_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "fk_playlist_track_playlist",
+      "Columns": "playlist_id",
+      "RelatedTable": "playlist",
+      "RelatedColumns": "playlist_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    },
+    {
+      "Name": "fk_playlist_track_track",
+      "Columns": "track_id",
+      "RelatedTable": "track",
+      "RelatedColumns": "track_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.track.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Tables/public.track.json
@@ -1,0 +1,102 @@
+{
+  "Name": "track",
+  "Columns": [
+    {
+      "Name": "album_id",
+      "DataType": "int4",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "composer",
+      "DataType": "varchar(220)",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "genre_id",
+      "DataType": "int4",
+      "Nullable": true,
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "media_type_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "milliseconds",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "name",
+      "DataType": "varchar(200)",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "track_id",
+      "DataType": "int4",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    },
+    {
+      "Name": "unit_price",
+      "DataType": "numeric(10, 2)",
+      "ShouldApplyExpression": "",
+      "OldName": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "ix_track_album_id",
+      "IndexColumns": "album_id",
+      "ShouldApplyExpression": ""
+    },
+    {
+      "Name": "pk_track",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "track_id",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "fk_track_album",
+      "Columns": "album_id",
+      "RelatedTable": "album",
+      "RelatedColumns": "album_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    },
+    {
+      "Name": "fk_track_genre",
+      "Columns": "genre_id",
+      "RelatedTable": "genre",
+      "RelatedColumns": "genre_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    },
+    {
+      "Name": "fk_track_media_type",
+      "Columns": "media_type_id",
+      "RelatedTable": "media_type",
+      "RelatedColumns": "media_type_id",
+      "DeleteAction": "",
+      "UpdateAction": "",
+      "ShouldApplyExpression": ""
+    }
+  ],
+  "CheckConstraints": [],
+  "ShouldApplyExpression": "",
+  "OldName": ""
+}

--- a/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Template.json
+++ b/Demos/Learn/module-04/postgres/solution/Templates/Chinook/Template.json
@@ -1,0 +1,83 @@
+{
+  "Name": "Chinook",
+  "DatabaseIdentificationScript": "SELECT datname FROM pg_database WHERE datname = '{{ChinookDb}}'",
+  "ScriptFolders": [
+    {
+      "FolderPath": "Before Scripts"
+    },
+    {
+      "FolderPath": "Schemas",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Schemas"
+    },
+    {
+      "FolderPath": "Domain Types",
+      "QuenchSlot": "Objects",
+      "ObjectType": "DomainTypes"
+    },
+    {
+      "FolderPath": "Enum Types",
+      "QuenchSlot": "Objects",
+      "ObjectType": "EnumTypes"
+    },
+    {
+      "FolderPath": "Composite Types",
+      "QuenchSlot": "Objects",
+      "ObjectType": "CompositeTypes"
+    },
+    {
+      "FolderPath": "Functions",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Functions"
+    },
+    {
+      "FolderPath": "Trigger Functions",
+      "QuenchSlot": "Objects",
+      "ObjectType": "TriggerFunctions"
+    },
+    {
+      "FolderPath": "Window Functions",
+      "QuenchSlot": "Objects",
+      "ObjectType": "WindowFunctions"
+    },
+    {
+      "FolderPath": "Aggregates",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Aggregates"
+    },
+    {
+      "FolderPath": "Procedures",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Procedures"
+    },
+    {
+      "FolderPath": "Sequences",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Sequences"
+    },
+    {
+      "FolderPath": "Rules",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Rules"
+    },
+    {
+      "FolderPath": "Triggers",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Triggers"
+    },
+    {
+      "FolderPath": "Views",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Views"
+    },
+    {
+      "FolderPath": "Table Data",
+      "QuenchSlot": "TableData"
+    },
+    {
+      "FolderPath": "After Scripts",
+      "QuenchSlot": "After"
+    }
+  ],
+  "ScriptTokens": {}
+}

--- a/Demos/Learn/module-04/postgres/tongs.settings.json
+++ b/Demos/Learn/module-04/postgres/tongs.settings.json
@@ -1,0 +1,14 @@
+{
+  "Source": {
+    "Server": "localhost",
+    "Port": "15432",
+    "User": "postgres",
+    "Password": "Learn!Passw0rd",
+    "Database": "chinook",
+    "Platform": "PostgreSQL",
+    "ConnectionProperties": {}
+  },
+  "Product": { "Path": "./Extracted", "Name": "Chinook" },
+  "Template": { "Name": "Chinook" },
+  "ShouldCast": { "Tables": true, "Schemas": true }
+}

--- a/Demos/Learn/module-04/sqlserver/seed.sql
+++ b/Demos/Learn/module-04/sqlserver/seed.sql
@@ -1,0 +1,73 @@
+-- Module 4 seed (SQL Server): a small "existing" music-catalog database that
+-- nobody has under source control yet. Plain DDL + a little data — NOT a
+-- SchemaSmith package. You'll point SchemaTongs at it and cast it into one.
+-- A trimmed-down slice of the classic Chinook sample schema.
+
+IF DB_ID('chinook') IS NULL CREATE DATABASE chinook;
+GO
+USE chinook;
+GO
+
+CREATE TABLE dbo.Artist (
+    ArtistId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Artist PRIMARY KEY,
+    Name NVARCHAR(120) NULL
+);
+
+CREATE TABLE dbo.Genre (
+    GenreId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Genre PRIMARY KEY,
+    Name NVARCHAR(120) NULL
+);
+
+CREATE TABLE dbo.MediaType (
+    MediaTypeId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_MediaType PRIMARY KEY,
+    Name NVARCHAR(120) NULL
+);
+
+CREATE TABLE dbo.Album (
+    AlbumId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Album PRIMARY KEY,
+    Title NVARCHAR(160) NOT NULL,
+    ArtistId INT NOT NULL CONSTRAINT FK_Album_Artist FOREIGN KEY REFERENCES dbo.Artist(ArtistId)
+);
+CREATE INDEX IX_Album_ArtistId ON dbo.Album(ArtistId);
+
+CREATE TABLE dbo.Track (
+    TrackId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Track PRIMARY KEY,
+    Name NVARCHAR(200) NOT NULL,
+    AlbumId INT NULL CONSTRAINT FK_Track_Album FOREIGN KEY REFERENCES dbo.Album(AlbumId),
+    MediaTypeId INT NOT NULL CONSTRAINT FK_Track_MediaType FOREIGN KEY REFERENCES dbo.MediaType(MediaTypeId),
+    GenreId INT NULL CONSTRAINT FK_Track_Genre FOREIGN KEY REFERENCES dbo.Genre(GenreId),
+    Composer NVARCHAR(220) NULL,
+    Milliseconds INT NOT NULL,
+    UnitPrice DECIMAL(10,2) NOT NULL
+);
+CREATE INDEX IX_Track_AlbumId ON dbo.Track(AlbumId);
+
+CREATE TABLE dbo.Playlist (
+    PlaylistId INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_Playlist PRIMARY KEY,
+    Name NVARCHAR(120) NULL
+);
+
+CREATE TABLE dbo.PlaylistTrack (
+    PlaylistId INT NOT NULL CONSTRAINT FK_PlaylistTrack_Playlist FOREIGN KEY REFERENCES dbo.Playlist(PlaylistId),
+    TrackId INT NOT NULL CONSTRAINT FK_PlaylistTrack_Track FOREIGN KEY REFERENCES dbo.Track(TrackId),
+    CONSTRAINT PK_PlaylistTrack PRIMARY KEY (PlaylistId, TrackId)
+);
+GO
+
+INSERT INTO dbo.Genre (Name) VALUES ('Rock'), ('Jazz'), ('Metal');
+INSERT INTO dbo.MediaType (Name) VALUES ('MPEG audio file'), ('AAC audio file');
+INSERT INTO dbo.Artist (Name) VALUES ('AC/DC'), ('Accept'), ('Aerosmith'), ('Miles Davis'), ('Metallica');
+INSERT INTO dbo.Album (Title, ArtistId) VALUES
+    ('For Those About To Rock We Salute You', 1),
+    ('Balls to the Wall', 2),
+    ('Big Ones', 3),
+    ('Kind of Blue', 4),
+    ('Master of Puppets', 5);
+INSERT INTO dbo.Track (Name, AlbumId, MediaTypeId, GenreId, Composer, Milliseconds, UnitPrice) VALUES
+    ('For Those About To Rock (We Salute You)', 1, 1, 1, 'Young, Young, Johnson', 343719, 0.99),
+    ('Balls to the Wall', 2, 1, 3, NULL, 342562, 0.99),
+    ('So What', 4, 1, 2, 'Miles Davis', 562000, 0.99),
+    ('Master of Puppets', 5, 1, 3, 'Hetfield, Ulrich, Burton, Hammett', 515000, 0.99);
+INSERT INTO dbo.Playlist (Name) VALUES ('My favorites');
+INSERT INTO dbo.PlaylistTrack (PlaylistId, TrackId) VALUES (1, 1), (1, 4);
+GO

--- a/Demos/Learn/module-04/sqlserver/solution/.json-schemas/indexedviews.sqlserver.schema
+++ b/Demos/Learn/module-04/sqlserver/solution/.json-schemas/indexedviews.sqlserver.schema
@@ -1,0 +1,88 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "Schema": {
+      "type": "string"
+    },
+    "Definition": {
+      "type": "string"
+    },
+    "ShouldApplyExpression": {
+      "type": "string"
+    },
+    "VariantName": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "Indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "PrimaryKey": {
+            "type": "boolean"
+          },
+          "Unique": {
+            "type": "boolean"
+          },
+          "UniqueConstraint": {
+            "type": "boolean"
+          },
+          "IndexColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "FilterExpression": {
+            "type": "string"
+          },
+          "CompressionType": {
+            "type": "string"
+          },
+          "Clustered": {
+            "type": "boolean"
+          },
+          "ColumnStore": {
+            "type": "boolean"
+          },
+          "FillFactor": {
+            "type": "integer",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "IncludeColumns": {
+            "type": "string"
+          },
+          "UpdateFillFactor": {
+            "type": "boolean"
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "IndexColumns"
+        ]
+      }
+    },
+    "Extensions": {}
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "Definition"
+  ]
+}

--- a/Demos/Learn/module-04/sqlserver/solution/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-04/sqlserver/solution/.json-schemas/products.sqlserver.schema
@@ -1,0 +1,79 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "ValidationScript": {
+      "type": "string"
+    },
+    "TemplateOrder": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "ServerToQuench": {
+            "type": "integer"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "BranchNameFile": {
+      "type": "string"
+    },
+    "BeforeBranchNameMask": {
+      "type": "string"
+    },
+    "AfterBranchNameMask": {
+      "type": "string"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "Platform": {
+      "type": "string",
+      "pattern": "Unknown|PostgreSQL|SqlServer|MySQL"
+    },
+    "MinimumVersion": {
+      "type": "string"
+    },
+    "CheckConstraintStyle": {
+      "type": "string",
+      "pattern": "ColumnLevel|TableLevel"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "ValidationScript"
+  ]
+}

--- a/Demos/Learn/module-04/sqlserver/solution/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-04/sqlserver/solution/.json-schemas/tables.sqlserver.schema
@@ -1,0 +1,364 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "Columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "DataType": {
+            "type": "string"
+          },
+          "Nullable": {
+            "type": "boolean"
+          },
+          "Default": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "OldName": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "DataType"
+        ]
+      }
+    },
+    "Indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "PrimaryKey": {
+            "type": "boolean"
+          },
+          "Unique": {
+            "type": "boolean"
+          },
+          "UniqueConstraint": {
+            "type": "boolean"
+          },
+          "IndexColumns": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "IndexColumns"
+        ]
+      }
+    },
+    "ForeignKeys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Columns": {
+            "type": "string"
+          },
+          "RelatedTable": {
+            "type": "string"
+          },
+          "RelatedColumns": {
+            "type": "string"
+          },
+          "DeleteAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "UpdateAction": {
+            "type": "string",
+            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Columns",
+          "RelatedTable",
+          "RelatedColumns"
+        ]
+      }
+    },
+    "CheckConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Expression": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Expression"
+        ]
+      }
+    },
+    "ShouldApplyExpression": {
+      "type": "string"
+    },
+    "DataDelivery": {
+      "type": "object",
+      "properties": {
+        "ContentFile": {
+          "type": "string"
+        },
+        "MergeType": {
+          "type": "string",
+          "pattern": "Insert|Insert/Update|Insert/Update/Delete"
+        },
+        "MatchColumns": {
+          "type": "string"
+        },
+        "MergeFilter": {
+          "type": "string"
+        },
+        "MergeDisableTriggers": {
+          "type": "boolean"
+        },
+        "MergeDisableRules": {
+          "type": "boolean"
+        },
+        "MergeUpdateDescendents": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "VariantName": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "OldName": {
+      "type": "string"
+    },
+    "Schema": {
+      "type": "string"
+    },
+    "CompressionType": {
+      "type": "string"
+    },
+    "IsTemporal": {
+      "type": "boolean"
+    },
+    "XmlIndexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "IsPrimary": {
+            "type": "boolean"
+          },
+          "Column": {
+            "type": "string"
+          },
+          "PrimaryIndex": {
+            "type": "string"
+          },
+          "SecondaryIndexType": {
+            "type": "string",
+            "pattern": "VALUE|PATH|PROPERTY"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Column"
+        ]
+      }
+    },
+    "Statistics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Columns": {
+            "type": "string"
+          },
+          "SampleSize": {
+            "type": "integer",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "FilterExpression": {
+            "type": "string"
+          },
+          "ShouldApplyExpression": {
+            "type": "string"
+          },
+          "VariantName": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+          },
+          "Extensions": {}
+        },
+        "additionalProperties": false,
+        "required": [
+          "Name",
+          "Columns"
+        ]
+      }
+    },
+    "FullTextIndex": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "FullTextCatalog": {
+              "type": "string"
+            },
+            "KeyIndex": {
+              "type": "string"
+            },
+            "ChangeTracking": {
+              "type": "string"
+            },
+            "StopList": {
+              "type": "string"
+            },
+            "Columns": {
+              "type": "string"
+            },
+            "ShouldApplyExpression": {
+              "type": "string"
+            },
+            "VariantName": {
+              "type": "string",
+              "maxLength": 128,
+              "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+            },
+            "Extensions": {}
+          },
+          "additionalProperties": false,
+          "required": [
+            "FullTextCatalog",
+            "KeyIndex",
+            "Columns"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "FullTextCatalog": {
+                "type": "string"
+              },
+              "KeyIndex": {
+                "type": "string"
+              },
+              "ChangeTracking": {
+                "type": "string"
+              },
+              "StopList": {
+                "type": "string"
+              },
+              "Columns": {
+                "type": "string"
+              },
+              "ShouldApplyExpression": {
+                "type": "string"
+              },
+              "VariantName": {
+                "type": "string",
+                "maxLength": 128,
+                "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+              },
+              "Extensions": {}
+            },
+            "additionalProperties": false,
+            "required": [
+              "FullTextCatalog",
+              "KeyIndex",
+              "Columns"
+            ]
+          }
+        }
+      ]
+    },
+    "UpdateFillFactor": {
+      "type": "boolean"
+    },
+    "EnableCDC": {
+      "type": "boolean"
+    },
+    "Extensions": {}
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name"
+  ]
+}

--- a/Demos/Learn/module-04/sqlserver/solution/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-04/sqlserver/solution/.json-schemas/templates.sqlserver.schema
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "properties": {
+    "Name": {
+      "type": "string"
+    },
+    "DatabaseIdentificationScript": {
+      "type": "string"
+    },
+    "VersionStampScript": {
+      "type": "string"
+    },
+    "IndexOnlyTableQuenches": {
+      "type": "boolean"
+    },
+    "ScriptFolders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "FolderPath": {
+            "type": "string"
+          },
+          "QuenchSlot": {
+            "type": "integer"
+          },
+          "ObjectType": {
+            "type": "string",
+            "pattern": "None|Views|Functions|Procedures|Triggers|Schemas|DataTypes|FullTextCatalogs|FullTextStopLists|XMLSchemaCollections|DDLTriggers|IndexedViews|DomainTypes|EnumTypes|CompositeTypes|TriggerFunctions|WindowFunctions|Aggregates|Sequences|Rules|MaterializedViews|Events"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "FolderPath"
+        ]
+      }
+    },
+    "ScriptTokens": {
+      "type": "object"
+    },
+    "UpdateFillFactor": {
+      "type": "boolean"
+    },
+    "BaselineValidationScript": {
+      "type": "string"
+    },
+    "Required": {
+      "type": "boolean"
+    },
+    "SkipIfReadOnly": {
+      "type": "boolean"
+    },
+    "ServerToQuench": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "DatabaseIdentificationScript",
+    "ServerToQuench"
+  ]
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Product.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Product.json
@@ -1,0 +1,15 @@
+{
+  "Name": "Chinook",
+  "ValidationScript": "SELECT CAST(CASE WHEN EXISTS(SELECT * FROM master.sys.databases WHERE [Name] = '{{ChinookDb}}') THEN 1 ELSE 0 END AS BIT)",
+  "TemplateOrder": [
+    "Chinook"
+  ],
+  "ScriptTokens": {
+    "ChinookDb": "chinook"
+  },
+  "ScriptFolders": [],
+  "BranchNameFile": "{{repo_path}}/.git/HEAD",
+  "BeforeBranchNameMask": "ref: refs/heads/",
+  "AfterBranchNameMask": "",
+  "Platform": "SqlServer"
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Album.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Album.json
@@ -1,0 +1,67 @@
+{
+  "Name": "[Album]",
+  "Columns": [
+    {
+      "Name": "[AlbumId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[ArtistId]",
+      "DataType": "INT",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Title]",
+      "DataType": "NVARCHAR(160)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[IX_Album_ArtistId]",
+      "IndexColumns": "[ArtistId]",
+      "CompressionType": "NONE"
+    },
+    {
+      "Name": "[PK_Album]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[AlbumId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "[FK_Album_Artist]",
+      "Columns": "[ArtistId]",
+      "RelatedTable": "[Artist]",
+      "RelatedColumns": "[ArtistId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    }
+  ],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Artist.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Artist.json
@@ -1,0 +1,43 @@
+{
+  "Name": "[Artist]",
+  "Columns": [
+    {
+      "Name": "[ArtistId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Name]",
+      "DataType": "NVARCHAR(120)",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[PK_Artist]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[ArtistId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Genre.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Genre.json
@@ -1,0 +1,43 @@
+{
+  "Name": "[Genre]",
+  "Columns": [
+    {
+      "Name": "[GenreId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Name]",
+      "DataType": "NVARCHAR(120)",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[PK_Genre]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[GenreId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.MediaType.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.MediaType.json
@@ -1,0 +1,43 @@
+{
+  "Name": "[MediaType]",
+  "Columns": [
+    {
+      "Name": "[MediaTypeId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Name]",
+      "DataType": "NVARCHAR(120)",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[PK_MediaType]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[MediaTypeId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Playlist.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Playlist.json
@@ -1,0 +1,43 @@
+{
+  "Name": "[Playlist]",
+  "Columns": [
+    {
+      "Name": "[Name]",
+      "DataType": "NVARCHAR(120)",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[PlaylistId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[PK_Playlist]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[PlaylistId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.PlaylistTrack.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.PlaylistTrack.json
@@ -1,0 +1,61 @@
+{
+  "Name": "[PlaylistTrack]",
+  "Columns": [
+    {
+      "Name": "[PlaylistId]",
+      "DataType": "INT",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[TrackId]",
+      "DataType": "INT",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[PK_PlaylistTrack]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[PlaylistId],[TrackId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "[FK_PlaylistTrack_Playlist]",
+      "Columns": "[PlaylistId]",
+      "RelatedTable": "[Playlist]",
+      "RelatedColumns": "[PlaylistId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    },
+    {
+      "Name": "[FK_PlaylistTrack_Track]",
+      "Columns": "[TrackId]",
+      "RelatedTable": "[Track]",
+      "RelatedColumns": "[TrackId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    }
+  ],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Track.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Tables/dbo.Track.json
@@ -1,0 +1,138 @@
+{
+  "Name": "[Track]",
+  "Columns": [
+    {
+      "Name": "[AlbumId]",
+      "DataType": "INT",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Composer]",
+      "DataType": "NVARCHAR(220)",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[GenreId]",
+      "DataType": "INT",
+      "Nullable": true,
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[MediaTypeId]",
+      "DataType": "INT",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Milliseconds]",
+      "DataType": "INT",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[Name]",
+      "DataType": "NVARCHAR(200)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[TrackId]",
+      "DataType": "INT IDENTITY(1, 1)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    },
+    {
+      "Name": "[UnitPrice]",
+      "DataType": "DECIMAL(10, 2)",
+      "OldName": "",
+      "Collation": "",
+      "DataMaskFunction": "",
+      "EncryptionType": "NONE",
+      "EncryptionKey": "",
+      "EncryptionAlgorithm": ""
+    }
+  ],
+  "Indexes": [
+    {
+      "Name": "[IX_Track_AlbumId]",
+      "IndexColumns": "[AlbumId]",
+      "CompressionType": "NONE"
+    },
+    {
+      "Name": "[PK_Track]",
+      "PrimaryKey": true,
+      "Unique": true,
+      "IndexColumns": "[TrackId]",
+      "CompressionType": "NONE",
+      "Clustered": true
+    }
+  ],
+  "ForeignKeys": [
+    {
+      "Name": "[FK_Track_Album]",
+      "Columns": "[AlbumId]",
+      "RelatedTable": "[Album]",
+      "RelatedColumns": "[AlbumId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    },
+    {
+      "Name": "[FK_Track_Genre]",
+      "Columns": "[GenreId]",
+      "RelatedTable": "[Genre]",
+      "RelatedColumns": "[GenreId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    },
+    {
+      "Name": "[FK_Track_MediaType]",
+      "Columns": "[MediaTypeId]",
+      "RelatedTable": "[MediaType]",
+      "RelatedColumns": "[MediaTypeId]",
+      "DeleteAction": "NO ACTION",
+      "UpdateAction": "NO ACTION",
+      "RelatedTableSchema": "[dbo]"
+    }
+  ],
+  "CheckConstraints": [],
+  "OldName": "",
+  "Schema": "[dbo]",
+  "CompressionType": "NONE",
+  "XmlIndexes": [],
+  "Statistics": []
+}

--- a/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Template.json
+++ b/Demos/Learn/module-04/sqlserver/solution/Templates/Chinook/Template.json
@@ -1,0 +1,68 @@
+{
+  "Name": "Chinook",
+  "DatabaseIdentificationScript": "SELECT [Name] FROM master.sys.databases WHERE [Name] = '{{ChinookDb}}'",
+  "ScriptFolders": [
+    {
+      "FolderPath": "Before Scripts"
+    },
+    {
+      "FolderPath": "Schemas",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Schemas"
+    },
+    {
+      "FolderPath": "DataTypes",
+      "QuenchSlot": "Objects",
+      "ObjectType": "DataTypes"
+    },
+    {
+      "FolderPath": "FullTextCatalogs",
+      "QuenchSlot": "Objects",
+      "ObjectType": "FullTextCatalogs"
+    },
+    {
+      "FolderPath": "FullTextStopLists",
+      "QuenchSlot": "Objects",
+      "ObjectType": "FullTextStopLists"
+    },
+    {
+      "FolderPath": "XMLSchemaCollections",
+      "QuenchSlot": "Objects",
+      "ObjectType": "XMLSchemaCollections"
+    },
+    {
+      "FolderPath": "Functions",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Functions"
+    },
+    {
+      "FolderPath": "Views",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Views"
+    },
+    {
+      "FolderPath": "Procedures",
+      "QuenchSlot": "Objects",
+      "ObjectType": "Procedures"
+    },
+    {
+      "FolderPath": "Triggers",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "Triggers"
+    },
+    {
+      "FolderPath": "DDLTriggers",
+      "QuenchSlot": "AfterTablesObjects",
+      "ObjectType": "DDLTriggers"
+    },
+    {
+      "FolderPath": "Table Data",
+      "QuenchSlot": "TableData"
+    },
+    {
+      "FolderPath": "After Scripts",
+      "QuenchSlot": "After"
+    }
+  ],
+  "ScriptTokens": {}
+}

--- a/Demos/Learn/module-04/sqlserver/tongs.settings.json
+++ b/Demos/Learn/module-04/sqlserver/tongs.settings.json
@@ -1,0 +1,13 @@
+{
+  "Source": {
+    "Server": "localhost,11433",
+    "User": "sa",
+    "Password": "Learn!Passw0rd",
+    "Database": "chinook",
+    "Platform": "SqlServer",
+    "ConnectionProperties": { "TrustServerCertificate": "True" }
+  },
+  "Product": { "Path": "./Extracted", "Name": "Chinook" },
+  "Template": { "Name": "Chinook" },
+  "ShouldCast": { "Tables": true }
+}


### PR DESCRIPTION
Adds a self-contained, hands-on lab set under `Demos/Learn/` for learning SchemaSmith end-to-end against a throwaway three-engine sandbox (SQL Server, PostgreSQL, MySQL).

## What's here

- **`docker/`** — a three-engine sandbox (`docker compose up -d`) with `verify-sandbox.{sh,ps1}` connectivity checks. Empty engines plus a ready `learn` database on each.
- **`module-01`** — install & connect: kindle the forge on the `learn` database with a minimal empty package.
- **`module-02`** — your first schema package: declare a `Widget` table, quench it, and prove the re-run is a no-op (idempotency).
- **`module-03`** — change it & redeploy: widen a column and add one, preview the exact `ALTER` with WhatIf, then quench to converge. Includes a `whatif.settings.json` preview config per engine.
- **`module-04`** — bring an existing database under management: a plain-SQL `seed.sql` stands up a small "legacy" `chinook` music-catalog database (7 related tables), then SchemaTongs casts it into a schema package.

Each module ships per-engine `starter`/`solution` (or `seed.sql` + `tongs.settings.json` + `solution/` for module 4) for SQL Server, PostgreSQL, and MySQL.

## Verification

Every lab was run end-to-end against the sandbox on all three engines: deploys converge, WhatIf previews are no-ops, the idempotent re-runs change nothing, and the module-04 extraction reports 7 tables / 0 errors with primary keys, indexes, and foreign keys preserved.

## Notes

- Teaching/demo content under `Demos/` — no product code change and no `Schema/Scripts/` additions, so no copyright-header or CHANGELOG entry (not a release-to-release product delta).
- Lab packages are sample content, not domain-model changes — no editor JSON-schema regeneration implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)