### PR TITLE
Fix schema-template identifier handling: mixed-bracket source-schema refs (#272)

### DIFF
--- a/Schema/Schema.UnitTests/Utility/IdentifierTests.cs
+++ b/Schema/Schema.UnitTests/Utility/IdentifierTests.cs
@@ -83,4 +83,62 @@ public class IdentifierTests
         Assert.That(unwrappedConfig, Is.EqualTo(unwrappedFk),
             "Quote-wrapped source schema config and FK schema must unwrap to the same bare value");
     }
+
+    // ---- SplitQualifiedName (#272: delimiter-aware schema/object split) ----
+
+    [Test]
+    public void Split_SqlServer_FullyBracketed()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("[dbo].[Orders]", Platform.SqlServer);
+        Assert.That(schema, Is.EqualTo("dbo"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_SqlServer_Bare()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("dbo.Orders", Platform.SqlServer);
+        Assert.That(schema, Is.EqualTo("dbo"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_SqlServer_MixedBracketedSchemaBareObject()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("[dbo].Orders", Platform.SqlServer);
+        Assert.That(schema, Is.EqualTo("dbo"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_SqlServer_MixedBareSchemaBracketedObject()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("dbo.[Orders]", Platform.SqlServer);
+        Assert.That(schema, Is.EqualTo("dbo"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_SqlServer_DottedDelimitedSchema_NotMisSplit()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("[my.schema].[Orders]", Platform.SqlServer);
+        Assert.That(schema, Is.EqualTo("my.schema"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_PostgreSql_DottedDelimitedSchema_NotMisSplit()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("\"my.schema\".\"Orders\"", Platform.PostgreSQL);
+        Assert.That(schema, Is.EqualTo("my.schema"));
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
+
+    [Test]
+    public void Split_Unqualified_ReturnsNullSchema()
+    {
+        var (schema, name) = Identifier.SplitQualifiedName("Orders", Platform.SqlServer);
+        Assert.That(schema, Is.Null);
+        Assert.That(name, Is.EqualTo("Orders"));
+    }
 }

--- a/Schema/Utility/Identifier.cs
+++ b/Schema/Utility/Identifier.cs
@@ -39,4 +39,41 @@ public static class Identifier
                 return value;
         }
     }
+
+    /// <summary>
+    /// Splits a (possibly) schema-qualified identifier into its unwrapped
+    /// <c>(Schema, Name)</c> parts, treating the <c>.</c> separator as significant only
+    /// when it is OUTSIDE platform delimiter wrapping — so a delimited name that itself
+    /// contains a dot (<c>[my.schema]</c>, <c>"my.schema"</c>) is not mis-split. Both
+    /// parts are returned <see cref="Unwrap"/>-ed. <c>Schema</c> is <c>null</c> when the
+    /// value carries no top-level qualifier. Splits at the FIRST top-level dot (two-part
+    /// semantics); a multi-dot remainder is returned whole as <c>Name</c>.
+    /// </summary>
+    public static (string Schema, string Name) SplitQualifiedName(string value, Platform platform)
+    {
+        if (string.IsNullOrEmpty(value)) return (null, value);
+
+        var (open, close) = platform switch
+        {
+            Platform.SqlServer => ('[', ']'),
+            Platform.PostgreSQL => ('"', '"'),
+            Platform.MySQL => ('`', '`'),
+            _ => ('\0', '\0')
+        };
+
+        var inWrap = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (open != '\0')
+            {
+                if (!inWrap && c == open) { inWrap = true; continue; }
+                if (inWrap && c == close) { inWrap = false; continue; }
+            }
+            if (!inWrap && c == '.')
+                return (Unwrap(value.Substring(0, i), platform), Unwrap(value.Substring(i + 1), platform));
+        }
+
+        return (null, Unwrap(value, platform));
+    }
 }

--- a/SchemaTongs/SchemaTongs.IntegrationTests/SqlServer/SchemaTemplateRoundTripTests.cs
+++ b/SchemaTongs/SchemaTongs.IntegrationTests/SqlServer/SchemaTemplateRoundTripTests.cs
@@ -130,6 +130,20 @@ public class SchemaTemplateRoundTripTests
                 Assert.That(procBody, Does.Not.Contain($"[{SourceSchema}]"),
                     "Procedure body must no longer contain the bracketed source-schema literal.");
 
+                // #272: the mixed-bracket form [tenant_seed].Customers (bracketed schema, bare
+                // object — what the SSMS view designer emits) must also rewrite the schema half
+                // to {{SchemaName}}. Before the fix this survived un-rewritten and the package
+                // failed to quench with "Invalid object name 'tenant_seed.Customers'".
+                var mixedViewPath = Path.Combine(templatePath, "Views", "MixedRefView.sql");
+                Assert.That(File.Exists(mixedViewPath), Is.True,
+                    "MixedRefView.sql must be emitted with no schema prefix in the filename.");
+                var mixedViewBody = File.ReadAllText(mixedViewPath);
+                Assert.That(mixedViewBody, Does.Contain("{{SchemaName}}.Customers")
+                    .Or.Contain("{{SchemaName}}.[Customers]"),
+                    "Mixed-bracket [tenant_seed].Customers must rewrite the schema half to {{SchemaName}} (#272).");
+                Assert.That(mixedViewBody, Does.Not.Contain($"[{SourceSchema}].Customers"),
+                    "The bracketed-schema / bare-object source reference must not survive extraction (#272).");
+
                 // ----- Step 2: drop and recreate the source schema empty -----
                 DropAndRecreateTenantSchema();
 
@@ -285,6 +299,15 @@ AS
 SELECT c.[CustomerID], c.[Name], o.[OrderID]
   FROM [{SourceSchema}].[Customers] c
   INNER JOIN [{SourceSchema}].[Orders] o ON o.[CustomerID] = c.[CustomerID];";
+        cmd.ExecuteNonQuery();
+
+        // #272: a view using the SSMS view-designer MIXED-bracket form — bracketed schema,
+        // BARE object ([tenant_seed].Customers) — which the old same-wrapper rewriter missed.
+        cmd.CommandText = $@"
+CREATE VIEW [{SourceSchema}].[MixedRefView]
+AS
+SELECT c.[CustomerID], c.[Name]
+  FROM [{SourceSchema}].Customers c;";
         cmd.ExecuteNonQuery();
 
         // Procedure referencing BOTH source schema AND a cross-schema dbo object.

--- a/SchemaTongs/SchemaTongs.UnitTests/SchemaTemplateExtractionTests.cs
+++ b/SchemaTongs/SchemaTongs.UnitTests/SchemaTemplateExtractionTests.cs
@@ -323,6 +323,49 @@ public class SchemaTemplateExtractionTests
     }
 
     [Test]
+    public void SchemaTemplate_SqlServer_Fk_BracketedSameSchemaRelatedTableSchema_Stripped()
+    {
+        // Issue #272: bracketed RelatedTableSchema "[tenant_seed]" must be omitted the same as
+        // the bare "tenant_seed" form — this is the form GenerateTableJson actually emits
+        // ('[' + OBJECT_SCHEMA_NAME(...) + ']'). Pins the scrub LOGIC; the empirical throwaway-DB
+        // extraction (2026-06-18) confirmed real same-schema FK extraction omits RelatedTableSchema
+        // on current main (fresh + re-extraction). Anchor test for the reporter's #272 FK case.
+        lock (FactoryContainer.SharedLockObject)
+        {
+            SetUpMocks();
+            var overrides = ShouldCastAllFalse(Platform.SqlServer);
+            overrides["ShouldCast:Tables"] = "true";
+            RegisterConfig(Platform.SqlServer, overrides);
+
+            var tableListReader = SingleSqlServerTableListReader(SourceSchema, "Orders");
+            var jsonReader = SingleColumnReader(
+                "{\"Name\":\"Orders\",\"Schema\":\"tenant_seed\",\"OldName\":\"\",\"Columns\":[],\"ForeignKeys\":[" +
+                "{\"Name\":\"FK_Orders_Customers\",\"Columns\":\"CustomerId\",\"RelatedTable\":\"Customers\",\"RelatedColumns\":\"Id\",\"RelatedTableSchema\":\"[tenant_seed]\"}]}");
+            _command.ExecuteReader().Returns(tableListReader);
+            _commandJson.ExecuteReader().Returns(jsonReader);
+
+            string capturedJson = null;
+            _fileWrapper.When(f => f.WriteAllText(
+                Arg.Is<string>(s => s.EndsWith("Orders.json")),
+                Arg.Any<string>())).Do(ci => capturedJson = ci.ArgAt<string>(1));
+
+            var tongs = new SchemaTongs(Platform.SqlServer);
+            Assert.DoesNotThrow(() => tongs.CastTemplate());
+
+            Assert.That(capturedJson, Is.Not.Null);
+            var parsed = JObject.Parse(capturedJson);
+            var fks = (JArray)parsed["ForeignKeys"];
+            Assert.That(fks, Is.Not.Null);
+            Assert.That(fks.Count, Is.EqualTo(1));
+            Assert.That(fks[0]["RelatedTableSchema"], Is.Null,
+                "Bracketed same-source RelatedTableSchema ([tenant_seed]) should be stripped (issue #272)");
+
+            FactoryContainer.Clear();
+            LogFactory.Clear();
+        }
+    }
+
+    [Test]
     public void SchemaTemplate_SqlServer_Fk_CrossSchemaRelatedTableSchema_Preserved()
     {
         lock (FactoryContainer.SharedLockObject)

--- a/SchemaTongs/SchemaTongs.UnitTests/SqlBodyRewriterTests.cs
+++ b/SchemaTongs/SchemaTongs.UnitTests/SqlBodyRewriterTests.cs
@@ -51,6 +51,29 @@ public class SqlBodyRewriterTests
             "INSERT INTO {{SchemaName}}.[Orders] SELECT * FROM {{SchemaName}}.OrderStaging"));
     }
 
+    [Test]
+    public void MixedBracketedSchemaBareObject_Rewritten()
+    {
+        // Issue #272: the SSMS view-designer form — bracketed schema, bare object.
+        var result = Rewrite("SELECT * FROM [tenant_seed].Customers");
+        Assert.That(result.Body, Is.EqualTo("SELECT * FROM {{SchemaName}}.Customers"));
+    }
+
+    [Test]
+    public void MixedBareSchemaBracketedObject_Rewritten()
+    {
+        var result = Rewrite("SELECT * FROM tenant_seed.[Customers]");
+        Assert.That(result.Body, Is.EqualTo("SELECT * FROM {{SchemaName}}.[Customers]"));
+    }
+
+    [Test]
+    public void MixedForm_CrossSchema_StillPreserved()
+    {
+        // Guard: the relaxed matching must not start rewriting cross-schema refs.
+        var result = Rewrite("SELECT * FROM [dbo].Countries");
+        Assert.That(result.Body, Is.EqualTo("SELECT * FROM [dbo].Countries"));
+    }
+
     #endregion
 
     #region §7.3 — Cross-schema preservation

--- a/SchemaTongs/SchemaTongs.cs
+++ b/SchemaTongs/SchemaTongs.cs
@@ -2245,17 +2245,15 @@ SELECT mv.schemaname, mv.matviewname
                 var castPath = Path.Combine(_templatePath, reader["Folder"].ToString());
                 DirectoryWrapper.GetFromFactory().CreateDirectory(castPath);
                 var fullName = reader["FullName"].ToString();
-                if (_objectsToCast.Length > 0 && !_objectsToCast.Contains(fullName.ToLower()) && !_objectsToCast.Contains($"{fullName}.~~~".Split('.')[1].ToLower())) continue;
+                if (_objectsToCast.Length > 0 && !_objectsToCast.Contains(fullName.ToLower()) && !_objectsToCast.Contains(Identifier.SplitQualifiedName(fullName, _platform).Name.ToLower())) continue;
 
                 // Schema-template mode: skip objects outside the source schema; emit unqualified filenames.
-                var parts = fullName.Split('.');
-                if (_isSchemaTemplate && parts.Length >= 2)
-                {
-                    if (!ShouldExtractFromSchema(parts[0])) continue;
-                }
+                // Delimiter-aware split so a dotted delimited schema name ([my.schema]) is not mis-split (#272).
+                var (qualifiedSchema, objectName) = Identifier.SplitQualifiedName(fullName, _platform);
+                if (_isSchemaTemplate && qualifiedSchema != null && !ShouldExtractFromSchema(qualifiedSchema)) continue;
 
-                var outputName = _isSchemaTemplate && parts.Length >= 2
-                    ? EncodeFileName(parts[^1], ".sql")
+                var outputName = _isSchemaTemplate && qualifiedSchema != null
+                    ? EncodeFileName(objectName, ".sql")
                     : EncodeFullName(fullName, ".sql");
                 var fileName = ResolveOutputPath(castPath, outputName);
                 var folderName = reader["Folder"].ToString();
@@ -2539,7 +2537,7 @@ SELECT TABLE_SCHEMA, TABLE_NAME
             var castPath = Path.Combine(_templatePath, reader["Folder"].ToString());
             DirectoryWrapper.GetFromFactory().CreateDirectory(castPath);
             var fullName = reader["FullName"].ToString();
-            if (_objectsToCast.Length > 0 && !_objectsToCast.Contains(fullName.ToLower()) && !_objectsToCast.Contains($"{fullName}.~~~".Split('.')[1].ToLower())) continue;
+            if (_objectsToCast.Length > 0 && !_objectsToCast.Contains(fullName.ToLower()) && !_objectsToCast.Contains(Identifier.SplitQualifiedName(fullName, _platform).Name.ToLower())) continue;
 
             var fileName = ResolveOutputPath(castPath, EncodeFullName(fullName, ".sql"));
             if (ShouldSkipKnownBadScript(fileName)) { count++; continue; }

--- a/SchemaTongs/SqlBodyRewriter.cs
+++ b/SchemaTongs/SqlBodyRewriter.cs
@@ -17,8 +17,9 @@
 //     content inside them is treated as ordinary SQL. In practice this matters for
 //     PL/pgSQL function bodies extracted from <c>pg_proc.prosrc</c>. The conservative
 //     audit warning surfaces the affected files for human review (§7.4).
-//   * Bracket-delimited identifiers ([…]) and double-quoted identifiers ("…") on the
-//     SCHEMA side of a <c>schema.object</c> reference are recognised and rewritten.
+//   * The SCHEMA half of a `schema.object` reference is matched whether bracket-
+//     delimited, double-quoted, or bare, independently of how the OBJECT half is
+//     quoted (issue #272 mixed forms). The object token is preserved verbatim.
 //
 // The rewriter is invoked by SchemaTongs when in schema-template mode (i.e. when
 // Source.Schema is non-empty in SchemaTongs.settings.json). The
@@ -95,28 +96,19 @@ public static class SqlBodyRewriter
             return $"{MaskStart}{literals.Count - 1}{MaskEnd}";
         });
 
-        // Step 2: rewrite source-schema-qualified references in their three forms.
+        // Step 2: rewrite source-schema-qualified references. The schema half may be
+        // bracket-delimited, double-quoted, or bare — independently of how the object half
+        // is quoted — so one pattern enumerates the three schema wrappings and a lookahead
+        // leaves the object token untouched. Issue #272: mixed forms such as `[src].name`
+        // (emitted by the SSMS view designer) were previously missed by the same-wrapper
+        // patterns. The leading lookbehind blocks substring (`tenant_seed_audit`) and
+        // alias.column (`c.tenant_seed`) false matches; the trailing lookahead requires a
+        // following object token (word / quote / bracket).
         var escaped = Regex.Escape(sourceSchema);
-
-        // 2a. `[src].[name]` → `{{SchemaName}}.[name]`
-        var bracketed = new Regex($@"\[{escaped}\]\s*\.\s*\[(?<name>[^\]]+)\]",
+        var sourceQualified = new Regex(
+            $@"(?<![\w.])(?:\[{escaped}\]|""{escaped}""|\b{escaped}\b)\s*\.\s*(?=[\w""\[])",
             RegexOptions.Compiled);
-        masked = bracketed.Replace(masked, m => $"{SchemaToken}.[{m.Groups["name"].Value}]");
-
-        // 2b. `"src"."name"` → `{{SchemaName}}."name"`
-        var doubleQuoted = new Regex($@"""{escaped}""\s*\.\s*""(?<name>[^""]+)""",
-            RegexOptions.Compiled);
-        masked = doubleQuoted.Replace(masked, m => $"{SchemaToken}.\"{m.Groups["name"].Value}\"");
-
-        // 2c. `src.name` → `{{SchemaName}}.name` — guard with word-boundary lookbehind so
-        // we don't rewrite (a) `tenant_seed_audit.Log` where `tenant_seed` is a substring,
-        // or (b) `c.tenant_seed` where `tenant_seed` is the RHS column identifier.
-        // The (?<![\w.]) lookbehind blocks both a leading word character (substring) and
-        // a leading `.` (alias.column form). The (?=\.\w) lookahead ensures the source
-        // schema is followed by a `.name` reference, not bare.
-        var unbracketed = new Regex($@"(?<![\w.])\b{escaped}\b\s*\.\s*(?=[\w""\[])",
-            RegexOptions.Compiled);
-        masked = unbracketed.Replace(masked, $"{SchemaToken}.");
+        masked = sourceQualified.Replace(masked, $"{SchemaToken}.");
 
         // Step 3: walk the masked body line-by-line for unqualified table-like references.
         // The audit is best-effort — see §7.4: we never auto-prefix, we just surface lines


### PR DESCRIPTION
Closes #272.

Schema-template extraction now rewrites source-schema-qualified references independently of how each identifier half is delimited.

## Fixed
- **`SqlBodyRewriter`** — collapsed three same-wrapper regexes into one wrapping-flexible pass, so the mixed `[schema].object` form (bracketed schema, bare object — exactly what the SSMS view designer emits) is rewritten to `{{SchemaName}}`. Previously these survived un-rewritten and the extracted package failed to quench with `Invalid object name 'schema.object'`.
- **`Identifier.SplitQualifiedName`** — new delimiter-aware split, adopted in `PerformPostgreSqlCasting`, so a delimited schema/object name that legitimately contains a dot (`[my.schema]`, `"my.schema"`) is no longer mis-split.

## Tests
- **Unit:** `SqlBodyRewriter` mixed-form cases (all four bracket combinations), `Identifier.SplitQualifiedName`, and a bracketed same-source FK `RelatedTableSchema` omission guard.
- **Integration:** the schema-template round-trip now includes a mixed-bracket view and asserts the `{{SchemaName}}` rewrite end-to-end.

No CHANGELOG entry — the affected schema-template extraction feature is still unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)