### PR TITLE
release: v2.1.0 prep — folder-gate token fix (#260), docs, version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For full release details and download links, see [GitHub Releases](https://githu
 
 ## [Unreleased]
 
+## [v2.1.0]
+
 ### Added
 
 - **Folder-level conditional deployment (`ShouldApplyExpression` on folders).** Any product- or template-level script folder can now carry a `ShouldApplyExpression` — a SQL predicate evaluated against the target at deployment time. Blank deploys the folder (unchanged); a non-blank expression that returns true deploys it, false skips it (logged). The expression is arbitrary SQL in the target engine — read `SERVERPROPERTY`/`@@version`, call your own environment-type function, query a control table, or reference resolved tokens (including `{{SchemaName}}` on schema templates). Common uses: a `MariaDB/` vs `MySQL/` folder split by `@@version`, skipping `Jobs/` on Azure SQL, or keeping `TableData/TestData/` out of production. Evaluated per target; a malformed or erroring expression fails the deployment rather than silently skipping the folder. Same mental model as object-level `ShouldApplyExpression`, lifted to the folder. Cross-platform (SQL Server, PostgreSQL, MySQL). See [ShouldApplyExpression and Conditional Deployment](docs/end-user/reference/schemaquench.md#shouldapplyexpression-and-conditional-deployment) in the SchemaQuench reference. — #260

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <!-- ICU runtime version bundled with self-contained Linux publish output of CLI tools.
          Single source of truth — referenced by Directory.Packages.props, the three CLI csprojs'
          AppLocalIcu RuntimeHostConfigurationOption, and the release.yml ICU_VERSION env var

--- a/Schema/Domain/ScriptFolder.cs
+++ b/Schema/Domain/ScriptFolder.cs
@@ -32,6 +32,12 @@ namespace Schema.Domain
 
         public void LoadSqlFiles(string basePath, List<KeyValuePair<string, string>> scriptTokens, Platform platform = Platform.SqlServer)
         {
+            // The folder's gate expression takes the same script-token pass as its scripts (#260) — and
+            // independently of whether the folder has files — so a gate may reference any resolved token,
+            // not just literal SQL. SchemaName stays per-iteration (resolved at quench time).
+            if (!string.IsNullOrWhiteSpace(ShouldApplyExpression))
+                ShouldApplyExpression = SqlScript.TokenReplace(ShouldApplyExpression, scriptTokens, platform);
+
             var sqlFilePath = Path.Combine(basePath, FolderPath);
             if (!ProductDirectoryWrapper.GetFromFactory().Exists(sqlFilePath)) return;
             var files = ProductDirectoryWrapper.GetFromFactory()

--- a/Schema/Schema.UnitTests/Domain/ScriptFolderTests.cs
+++ b/Schema/Schema.UnitTests/Domain/ScriptFolderTests.cs
@@ -1,5 +1,8 @@
 // Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
 using Schema.Domain;
@@ -221,6 +224,83 @@ namespace Schema.UnitTests.Domain
             var clone = original.Clone();
 
             Assert.That(clone.ShouldApplyExpression, Is.EqualTo("SELECT 1"));
+        }
+
+        // ---- ShouldApplyExpression script-token resolution (#260 bug: gate expressions skipped the token pass) ----
+
+        private static string NonexistentBasePath() =>
+            Path.Combine(Path.GetTempPath(), "ss-folder-gate-" + Guid.NewGuid().ToString("N"));
+
+        [Test]
+        public void LoadSqlFiles_ResolvesScriptTokensInShouldApplyExpression()
+        {
+            var folder = new TemplateFolder
+            {
+                FolderPath = "EnvGated",
+                QuenchSlot = TemplateQuenchSlot.Before,
+                ShouldApplyExpression = "'{{EnvType}}' = 'prod'"
+            };
+
+            folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")]);
+
+            Assert.That(folder.ShouldApplyExpression, Is.EqualTo("'prod' = 'prod'"));
+        }
+
+        [Test]
+        public void LoadSqlFiles_ResolvesScriptTokensInShouldApplyExpression_OnProductFolder()
+        {
+            var folder = new ProductFolder
+            {
+                FolderPath = "EnvGated",
+                QuenchSlot = ProductQuenchSlot.Before,
+                ShouldApplyExpression = "'{{EnvType}}' = 'prod'"
+            };
+
+            folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")]);
+
+            Assert.That(folder.ShouldApplyExpression, Is.EqualTo("'prod' = 'prod'"));
+        }
+
+        [Test]
+        public void LoadSqlFiles_WithNullShouldApplyExpression_LeavesItNull()
+        {
+            var folder = new TemplateFolder { FolderPath = "Plain", QuenchSlot = TemplateQuenchSlot.Before };
+
+            folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")]);
+
+            Assert.That(folder.ShouldApplyExpression, Is.Null);
+        }
+
+        [Test]
+        public void LoadSqlFiles_LeavesSchemaNameTokenForPerIterationSubstitution()
+        {
+            // SchemaName is per-iteration (resolved at quench time by DatabaseQuench), so it must NOT
+            // be in the load-time token set and must survive this pass intact.
+            var folder = new TemplateFolder
+            {
+                FolderPath = "SchemaScoped",
+                QuenchSlot = TemplateQuenchSlot.Before,
+                ShouldApplyExpression = "'{{SchemaName}}' = 'tenant_a'"
+            };
+
+            folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")]);
+
+            Assert.That(folder.ShouldApplyExpression, Is.EqualTo("'{{SchemaName}}' = 'tenant_a'"));
+        }
+
+        [Test]
+        public void LoadSqlFiles_WithNoTokensInShouldApplyExpression_LeavesItUnchanged()
+        {
+            var folder = new TemplateFolder
+            {
+                FolderPath = "Plain",
+                QuenchSlot = TemplateQuenchSlot.Before,
+                ShouldApplyExpression = "SELECT CASE WHEN @@version LIKE '%MariaDB%' THEN 1 ELSE 0 END"
+            };
+
+            folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")]);
+
+            Assert.That(folder.ShouldApplyExpression, Is.EqualTo("SELECT CASE WHEN @@version LIKE '%MariaDB%' THEN 1 ELSE 0 END"));
         }
     }
 }

--- a/SchemaQuench/SchemaQuench.IntegrationTests/MySQL/FolderGateIntegrationTests.cs
+++ b/SchemaQuench/SchemaQuench.IntegrationTests/MySQL/FolderGateIntegrationTests.cs
@@ -1,5 +1,8 @@
 // Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Schema.DataAccess;
 using Schema.Domain;
@@ -44,4 +47,27 @@ public class FolderGateIntegrationTests
                 Is.True, "A real predicate returning Int64 evaluates true on MySQL.");
         });
     }
+
+    [Test]
+    public void FolderGate_LiveMySql_EvaluatesResolvedScriptToken()
+    {
+        // #260 fix: a gate may reference a script token, which is resolved before evaluation.
+        // Pre-fix the unresolved '{{EnvType}}' would never equal 'prod' and the gate would read false.
+        var folder = new TemplateFolder
+        {
+            FolderPath = "EnvGated",
+            QuenchSlot = TemplateQuenchSlot.Before,
+            ShouldApplyExpression = "SELECT CASE WHEN '{{EnvType}}' = 'prod' THEN 1 ELSE 0 END"
+        };
+        folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")], Platform.MySQL);
+
+        using var conn = DbConnectionFactory.ForPlatform(Platform.MySQL).GetDbConnection(_connectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+
+        Assert.That(FolderGate.ShouldApply(cmd, folder.ShouldApplyExpression), Is.True);
+    }
+
+    private static string NonexistentBasePath() =>
+        Path.Combine(Path.GetTempPath(), "ss-folder-gate-" + Guid.NewGuid().ToString("N"));
 }

--- a/SchemaQuench/SchemaQuench.IntegrationTests/PostgreSQL/FolderGateIntegrationTests.cs
+++ b/SchemaQuench/SchemaQuench.IntegrationTests/PostgreSQL/FolderGateIntegrationTests.cs
@@ -1,5 +1,8 @@
 // Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Schema.DataAccess;
 using Schema.Domain;
@@ -43,4 +46,27 @@ public class FolderGateIntegrationTests
                 Is.True, "A real native-boolean predicate evaluates true on PostgreSQL.");
         });
     }
+
+    [Test]
+    public void FolderGate_LivePostgreSql_EvaluatesResolvedScriptToken()
+    {
+        // #260 fix: a gate may reference a script token, which is resolved before evaluation.
+        // Pre-fix the unresolved '{{EnvType}}' would never equal 'prod' and the gate would read false.
+        var folder = new TemplateFolder
+        {
+            FolderPath = "EnvGated",
+            QuenchSlot = TemplateQuenchSlot.Before,
+            ShouldApplyExpression = "SELECT '{{EnvType}}' = 'prod'"
+        };
+        folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")], Platform.PostgreSQL);
+
+        using var conn = DbConnectionFactory.ForPlatform(Platform.PostgreSQL).GetDbConnection(_connectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+
+        Assert.That(FolderGate.ShouldApply(cmd, folder.ShouldApplyExpression), Is.True);
+    }
+
+    private static string NonexistentBasePath() =>
+        Path.Combine(Path.GetTempPath(), "ss-folder-gate-" + Guid.NewGuid().ToString("N"));
 }

--- a/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/FolderGateIntegrationTests.cs
+++ b/SchemaQuench/SchemaQuench.IntegrationTests/SqlServer/FolderGateIntegrationTests.cs
@@ -1,5 +1,8 @@
 // Copyright (c) SchemaSmith Contributors. Licensed under the SSCL v2.0.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Schema.DataAccess;
 using Schema.Domain;
@@ -45,4 +48,27 @@ public class FolderGateIntegrationTests
                 Is.True, "A real server-property predicate evaluates true on SQL Server.");
         });
     }
+
+    [Test]
+    public void FolderGate_LiveSqlServer_EvaluatesResolvedScriptToken()
+    {
+        // #260 fix: a gate may reference a script token, which is resolved before evaluation.
+        // Pre-fix the unresolved '{{EnvType}}' would never equal 'prod' and the gate would read false.
+        var folder = new TemplateFolder
+        {
+            FolderPath = "EnvGated",
+            QuenchSlot = TemplateQuenchSlot.Before,
+            ShouldApplyExpression = "SELECT CASE WHEN '{{EnvType}}' = 'prod' THEN 1 ELSE 0 END"
+        };
+        folder.LoadSqlFiles(NonexistentBasePath(), [new KeyValuePair<string, string>("EnvType", "prod")], Platform.SqlServer);
+
+        using var conn = DbConnectionFactory.ForPlatform(Platform.SqlServer).GetDbConnection(_connectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+
+        Assert.That(FolderGate.ShouldApply(cmd, folder.ShouldApplyExpression), Is.True);
+    }
+
+    private static string NonexistentBasePath() =>
+        Path.Combine(Path.GetTempPath(), "ss-folder-gate-" + Guid.NewGuid().ToString("N"));
 }

--- a/docs/end-user/guide/09-power-workflows.md
+++ b/docs/end-user/guide/09-power-workflows.md
@@ -178,10 +178,11 @@ The same `(variant: ...)` suffix appears in WhatIf output, so a dry run tells yo
 
 ### Conditional deployment: whole table vs. within a table
 
-`ShouldApplyExpression` works at two levels, and it helps to keep them straight:
+`ShouldApplyExpression` works at more than one level, and it helps to keep them straight:
 
 - **Within a table.** Columns, indexes, foreign keys, check constraints, statistics, and the other components inside a table file can each declare conditional variants -- same name, mutually exclusive expressions -- and the matching one is chosen per target. These variant sets are fully preserved when SchemaTongs re-extracts the table.
 - **The whole table.** A table-level `ShouldApplyExpression` gates the entire table present-or-absent on a given target, and that gating round-trips through extraction too.
+- **A whole folder.** A product- or template-level script folder can carry a `ShouldApplyExpression`, so an entire folder of scripts deploys or is skipped per target -- a `MariaDB/` variant gated on `@@version`, a `Jobs/` folder skipped on Azure SQL, or `TableData/TestData/` kept out of production. Its tokens are resolved before evaluation, like every other gate. See [Conditional Deployment](../reference/schemaquench.md#shouldapplyexpression-and-conditional-deployment).
 
 **Recommendation:** to vary a table's *structure* by target, prefer component-level variants inside a single table file (or give the structurally different tables distinct names). Two separate same-named whole-table variant files will deploy correctly, but SchemaTongs normalizes a table to one file per name on extraction, so a multi-file same-named-table layout isn't reproduced when you re-extract.
 

--- a/docs/end-user/reference/schema-packages.md
+++ b/docs/end-user/reference/schema-packages.md
@@ -155,6 +155,7 @@ The array is an explicit replacement, not a merge. The moment you provide `Scrip
 | `FolderPath` | string | Yes | Relative path under the template directory. Forward or back slashes both work. |
 | `QuenchSlot` | string | Yes | Which execution slot the folder runs in. See [Quench Slot Reference](#quench-slot-reference) below for valid values. |
 | `ObjectType` | string | No | When the folder contains programmable objects (functions, views, procedures, triggers, etc.), tag it with the corresponding object type so SchemaQuench can route it through the dependency-retry loop correctly. |
+| `ShouldApplyExpression` | string | No | Optional SQL predicate evaluated against the target at deploy time (tokens resolved first): true deploys the folder, false skips it (logged), blank always deploys. See [Conditional Deployment](schemaquench.md#shouldapplyexpression-and-conditional-deployment). |
 
 ### Example -- adding a custom folder for an extra migration step
 
@@ -185,7 +186,7 @@ Custom script folders are how you make the schema package fit *your* deployment 
 
 ### Custom product-level folders
 
-`Product.json` can also declare custom folders via its `ScriptFolders` array (the property name is the same as `Template.json`'s). The shape is similar but uses `ProductQuenchSlot` (`Before` or `After`) and supports a `ServerToQuench` setting that controls whether the folder runs on the primary, secondaries, or both. See [Secondary Servers](#secondary-servers) below.
+`Product.json` can also declare custom folders via its `ScriptFolders` array (the property name is the same as `Template.json`'s). The shape is similar but uses `ProductQuenchSlot` (`Before` or `After`) and supports a `ServerToQuench` setting that controls whether the folder runs on the primary, secondaries, or both. See [Secondary Servers](#secondary-servers) below. Product folders also accept a `ShouldApplyExpression`, evaluated per server against the admin connection -- see [Conditional Deployment](schemaquench.md#shouldapplyexpression-and-conditional-deployment).
 
 ---
 


### PR DESCRIPTION
Release-prep PR for **v2.1.0**. Folds the folder-gate bug fix together with the version bump, CHANGELOG stamp, and the two doc gaps the pre-release audit surfaced.

## 1. Folder-gate token resolution (#260)

Folder-level `ShouldApplyExpression` was the only gate expression in the domain that skipped the script-token resolution pass. Product folders evaluated it raw; template folders resolved only `{{SchemaName}}`. A gate referencing a user-defined token — e.g. `'{{EnvType}}' = 'prod'` — reached the engine literally and never matched.

Fixed in `ScriptFolder.LoadSqlFiles` — the single method both the template (`Template.ResolveScriptTokens`) and product (`Product.InstanceLoad`) load paths already call with the token set. Guarded to non-blank so `null` is preserved, placed before the directory early-return so a gated folder with no files still resolves. `{{SchemaName}}` is left for the existing per-iteration substitution at quench time. Matches how every other `ShouldApplyExpression` resolves; query tokens stay out of gates, same as object-level gates.

## 2. Docs — #260 discoverability

- `schema-packages.md`: `ShouldApplyExpression` added to the TemplateFolder property table and the custom product-folder paragraph.
- `09-power-workflows.md`: folder level added to the conditional-deployment "levels" model.

Both cross-reference the canonical SchemaQuench Conditional Deployment section (which already documented token resolution — this fix makes that claim hold).

## 3. Release stamp

- `Directory.Build.props`: `<Version>` 2.0.0 → 2.1.0
- `CHANGELOG.md`: `[Unreleased]` → `[v2.1.0]`, fresh empty `[Unreleased]`. Minor bump — everything since v2.0.0 is additive plus the one mitigated `Required`→`RequireAtLeastOneTarget` rename (migration note in its entry).

## Verification

- **Unit:** Schema 1466 + SchemaQuench 356, plus new `ScriptFolderTests` (token resolution on template + product folders, `null` preserved, no-op without tokens, `{{SchemaName}}` survives the load-time pass)
- **Integration, all 3 engines (0 failures):** SchemaQuench 614, Schema 122, SchemaTongs 73, DataTongs 117 — including a per-engine `EvaluatesResolvedScriptToken` gate test
- **Build:** 0 warnings · shellcheck + actionlint clean
- **Schema-artifact regen:** no drift across 33 product dirs
- **`dotnet publish` win-x64 smoke:** all three tools start, report v2.1.0.0
- **Independent code review:** clean verdict

## Notes

- The fix needs no separate CHANGELOG entry — it's a defect inside the unreleased #260 feature, folding into that feature's entry.
- README banner is intentionally **not** in this PR — it's the release-window step (announces a live release, links to a tag that won't exist until the cut).
- After merge, the cut is mechanical: trigger `release.yml` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)