### PR TITLE
docs(demos): Learn lab CLI version-string hygiene (soften safe + pin release-coupled)

### DIFF
--- a/Demos/Learn/course3-module-01/README.md
+++ b/Demos/Learn/course3-module-01/README.md
@@ -24,6 +24,7 @@ once under `solution/` — each with its own `Package/` and `dev.settings.json` 
 
   It creates the nine `ordersservice_{dev,staging,prod}` databases across the three engines and
   reports `PASS` for each.
+<!-- TRAINING-RELEASE-PIN #288: the PostgreSQL "re-run is a no-op" step in this lab is valid only on a CLI release that includes the #287/#288 string-default fix. When a release includes it: set this pre-flight version to that release, re-certify the PG no-op, and remove this marker. -->
 - The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0`).
 
 ## Step 1: Establish the base (the v1 package)

--- a/Demos/Learn/course3-module-02/README.md
+++ b/Demos/Learn/course3-module-02/README.md
@@ -50,6 +50,7 @@ Environment-variable mapping follows the standard convention: prefix `SmithySett
   ```
 
   It creates the nine `ordersservice_{dev,staging,prod}` databases and reports `PASS` for each.
+<!-- TRAINING-RELEASE-PIN #288: the PostgreSQL "re-run is a no-op" step in this lab is valid only on a CLI release that includes the #287/#288 string-default fix. When a release includes it: set this pre-flight version to that release, re-certify the PG no-op, and remove this marker. -->
 - The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0`).
 
 ## Run the pipeline

--- a/Demos/Learn/course3-module-03/README.md
+++ b/Demos/Learn/course3-module-03/README.md
@@ -55,6 +55,7 @@ on a `{{TargetDb}}` script token, exactly as in Module 2, so one package targets
   It creates the `ordersservice_{dev,staging,prod}` databases on each engine and reports `PASS`. This
   lab uses **`ordersservice_dev`** — the first `v1` deploy converges dev to the v1 state regardless of
   what was there before.
+<!-- TRAINING-RELEASE-PIN #288: the PostgreSQL "re-run is a no-op" step in this lab is valid only on a CLI release that includes the #287/#288 string-default fix. When a release includes it: set this pre-flight version to that release, re-certify the PG no-op, and remove this marker. -->
 - The CLI is reachable. The commands below assume `schemaquench` is on your PATH
   (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0`). If you'd rather not put it on
   the PATH, set `SCHEMAQUENCH` to the full path to the executable and substitute `$SCHEMAQUENCH` for

--- a/Demos/Learn/course3-module-04/README.md
+++ b/Demos/Learn/course3-module-04/README.md
@@ -54,6 +54,7 @@ that varies per environment is injected as an env var at run time, identical to 
   ```
 
   It creates the nine `ordersservice_{dev,staging,prod}` databases and reports `PASS` for each.
+<!-- TRAINING-RELEASE-PIN #288: the PostgreSQL "re-run is a no-op" step in this lab is valid only on a CLI release that includes the #287/#288 string-default fix. When a release includes it: set this pre-flight version to that release, re-certify the PG no-op, and remove this marker. -->
 - The CLI is reachable. The commands below assume `schemaquench` is on your PATH
   (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0`). If you'd rather not put it on
   the PATH, set `SCHEMAQUENCH` to the full path to the executable and substitute `$SCHEMAQUENCH` for

--- a/Demos/Learn/level2-module-01/README.md
+++ b/Demos/Learn/level2-module-01/README.md
@@ -27,7 +27,7 @@ Each engine folder (`sqlserver/`, `postgres/`, `mysql/`) has both products, each
 
 - The [sandbox](../docker) is up (`docker compose up -d`) and verified (`./verify-sandbox.sh` /
   `.\verify-sandbox.ps1` — all three engines `PASS`).
-- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.0.0.0`).
+- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0` or later).
 
 ## Step 1: Look at the two products
 

--- a/Demos/Learn/level2-module-02/README.md
+++ b/Demos/Learn/level2-module-02/README.md
@@ -39,6 +39,7 @@ two-engine feature, not because a third engine was skipped.
 
 - The [sandbox](../docker) is up (`docker compose up -d`) and verified (`./verify-sandbox.sh` /
   `.\verify-sandbox.ps1` — SQL Server and PostgreSQL `PASS`).
+<!-- TRAINING-RELEASE-PIN #288: the PostgreSQL "re-run is a no-op" step in this lab is valid only on a CLI release that includes the #287/#288 string-default fix. When a release includes it: set this pre-flight version to that release, re-certify the PG no-op, and remove this marker. -->
 - The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.0.0.0`).
 
 ## Step 1: Look at the two templates

--- a/Demos/Learn/level2-module-04/README.md
+++ b/Demos/Learn/level2-module-04/README.md
@@ -24,7 +24,7 @@ This lab ships one product, `BillingService`, on all three engines. Each engine 
 
 - The [sandbox](../docker) is up (`docker compose up -d`) and verified (`./verify-sandbox.sh` /
   `.\verify-sandbox.ps1` — all three engines `PASS`).
-- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.0.0.0`).
+- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0` or later).
 
 ## Step 1: Look at the token contract
 

--- a/Demos/Learn/level2-module-05/README.md
+++ b/Demos/Learn/level2-module-05/README.md
@@ -22,7 +22,7 @@ Each engine folder (`sqlserver/`, `postgres/`, `mysql/`) ships the full `Package
 ## Before you start
 
 - The [sandbox](../docker) is up (`docker compose up -d`) and verified (all three engines `PASS`).
-- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.0.0.0`;
+- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0` or later;
   `datatongs --version` is available too).
 
 ## Step 1: Look at the delivery declaration

--- a/Demos/Learn/level2-module-06/README.md
+++ b/Demos/Learn/level2-module-06/README.md
@@ -21,7 +21,7 @@ Each engine folder (`sqlserver/`, `postgres/`, `mysql/`) ships the full `Package
 ## Before you start
 
 - The [sandbox](../docker) is up (`docker compose up -d`) and verified (all three engines `PASS`).
-- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.0.0.0`).
+- The CLI is on your PATH (`schemaquench --version` reports `SchemaQuench - Version: 2.1.0.0` or later).
 
 ## Step 1: Look at the metadata
 

--- a/Demos/Learn/module-01/README.md
+++ b/Demos/Learn/module-01/README.md
@@ -19,10 +19,10 @@ schemaquench --version
 Expected:
 
 ```
-SchemaQuench - Version: 2.0.0.0
+SchemaQuench - Version: 2.1.0.0
 ```
 
-If the command isn't found, the CLI isn't on your PATH — revisit the install guide.
+Your exact version may be `2.1.0.0` or later — any version line means the CLI is installed and on your PATH. If the command isn't found, revisit the install guide.
 
 ## Step 2: Connect and kindle each engine
 


### PR DESCRIPTION
A complete pass over the `schemaquench --version` pre-flight checks across all ten `Demos/Learn/` lab READMEs.

**Softened (safe — no version-dependent claim):** `2.0.0.0` → `2.1.0.0` or later, matching the form already used in `level2-module-03`:
- `module-01` (example `--version` output + an "or later" framing note)
- `level2-module-01`, `level2-module-04`, `level2-module-05`, `level2-module-06`

**Pinned (release-coupled):** five labs whose PostgreSQL "re-run is a no-op" step is valid only on a release that includes the #287/#288 string-literal-default fix get an in-file `<!-- TRAINING-RELEASE-PIN #288: … -->` sentinel (invisible in the rendered README, grep-able in source) naming the action to take when such a release ships. Their displayed version strings are intentionally left until that release:
- `course3-module-01`, `course3-module-02`, `course3-module-03`, `course3-module-04`, `level2-module-02`

Doc-only teaching content under `Demos/Learn/`: no code change, no CHANGELOG entry, no schema-artifact regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)