### PR TITLE
Preserve Extensions fragments at every level (#320) + RC2 dep bump + editor-schema refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to SchemaSmith Community Edition are documented here.
 
 For full release details and download links, see [GitHub Releases](https://github.com/Schema-Smith/SchemaSmith/releases).
 
+## [Unreleased]
+
+### Fixed
+
+- **Hand-authored `Extensions` schema-fragment governance was only preserved at the table root on regeneration.** A custom JSON-Schema fragment added to the open `Extensions` bag in a generated `.json-schemas/*.schema` file — the documented way to enforce governance (required keys, value enums) on custom properties at PR time — survived regeneration only at the table's top level. A fragment authored at any deeper level — column, index, foreign key, check constraint, statistic, XML index, full-text index, exclude constraint, or the indexes of an indexed/materialized view — was silently discarded and rebuilt as an empty bag on every `--WriteSchemasOnly` run and every SchemaTongs extraction, contradicting the reference docs that instruct authoring column-level governance under `properties.Columns.items.properties.Extensions` and promise it survives the round-trip. The merge now carries over an authored `Extensions` fragment wherever it was defined — at every component level and across the table, materialized-view, and indexed-view schema variants — via a location-exact recursive merge, so nothing leaks across levels. Affected all three engines. — #320
+
 ## [v2.2.0](https://github.com/Schema-Smith/SchemaSmith/releases/tag/v2.2.0) — 2026-06-30
 
 ### Added

--- a/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-01/solution/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-01/solution/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/solution/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-01/starter/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-01/starter/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-01/starter/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-02/solution/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-02/solution/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/solution/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-02/starter/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-02/starter/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-02/starter/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-03/v1/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v1/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v1/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-03/v2/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-03/v2/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-03/v2/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-04/contract/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-04/contract/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/contract/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-04/expand/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-04/expand/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/expand/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course3-module-04/package/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course3-module-04/package/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course3-module-04/package/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-01/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-01/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-02/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-02/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-03/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-03/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-04/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-04/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-05/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-05/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package-NoPromotion/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course4-recipe-06/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package-NoPromotion/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course4-recipe-06/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package-NoPromotion/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course4-recipe-06/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course5-module-01/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course5-module-01/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course5-module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course5-module-02/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course5-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course5-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course5-module-03/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course5-module-03/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course5-module-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course5-module-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course5-module-05/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course5-module-05/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course5-module-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course6-module-01/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course6-module-01/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course6-module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/course6-module-02/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/course6-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/course6-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/appserver/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-01/mysql/common/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/appserver/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-01/postgres/common/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/appserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-01/sqlserver/common/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-02/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-02/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-03/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-03/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-03/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-04/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-04/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-04/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-05/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-05/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-05/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/level2-module-06/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/level2-module-06/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/level2-module-06/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/module-01/mysql/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-01/mysql/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-01/mysql/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-01/mysql/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-01/mysql/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-01/mysql/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-01/postgres/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-01/postgres/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-01/postgres/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-01/postgres/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-01/postgres/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-01/postgres/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-01/sqlserver/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-01/sqlserver/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-01/sqlserver/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-02/mysql/solution/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-02/mysql/starter/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/solution/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-02/postgres/starter/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/solution/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-02/sqlserver/starter/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-03/mysql/solution/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/products.mysql.schema
+++ b/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/products.mysql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/tables.mysql.schema
+++ b/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/tables.mysql.schema
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/templates.mysql.schema
+++ b/Demos/Learn/module-03/mysql/starter/Package/.json-schemas/templates.mysql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/solution/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/products.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/products.postgresql.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/tables.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/tables.postgresql.schema
@@ -255,6 +255,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/templates.postgresql.schema
+++ b/Demos/Learn/module-03/postgres/starter/Package/.json-schemas/templates.postgresql.schema
@@ -69,6 +69,30 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/solution/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/products.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/products.sqlserver.schema
@@ -74,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/tables.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/tables.sqlserver.schema
@@ -240,6 +240,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },

--- a/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/templates.sqlserver.schema
+++ b/Demos/Learn/module-03/sqlserver/starter/Package/.json-schemas/templates.sqlserver.schema
@@ -70,6 +70,30 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,22 +6,22 @@
 
   <ItemGroup>
     <!-- Core dependencies -->
-    <PackageVersion Include="log4net" Version="3.3.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="log4net" Version="3.3.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <!-- App-local ICU bundled with self-contained Linux publish output of CLI tools.
          Version is centralized via $(IcuVersion) in Directory.Build.props. -->
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="$(IcuVersion)" />
-    <PackageVersion Include="MySqlConnector" Version="2.5.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.6.1" />
     <!-- Newtonsoft.Json 13.0.4 — latest stable; 13.0.5 is beta only -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Npgsql" Version="10.0.2" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
 
-    <!-- Microsoft.Extensions — Configuration.* on 10.0.7 (latest); other sub-packages on 10.0.5 (latest published) -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
+    <!-- Microsoft.Extensions — Configuration.* on 10.0.9 (latest); other sub-packages on 10.0.5 (latest published) -->
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
@@ -47,11 +47,11 @@
 
     <!-- Test infrastructure -->
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <!-- NSubstitute 5.3.0 — latest stable; 6.0.0 is RC only -->
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit" Version="4.6.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/Schema/Schema.IntegrationTests/MySQL/FixtureSetup.cs
+++ b/Schema/Schema.IntegrationTests/MySQL/FixtureSetup.cs
@@ -80,7 +80,9 @@ public class FixtureSetup
 
         var mysqlProps = Schema.DataAccess.ConnectionString.ReadProperties(config, "MySQL:ConnectionProperties");
         var extraProps = string.Join("", mysqlProps.Select(p => $"{p.Key}={p.Value};"));
-        _connectionString = $"Server={server};Port={port};User={user};Password={password};AllowUserVariables=true;MaxPoolSize=100;{extraProps}";
+        // Non-pooled: the suite creates a unique database per test, and retained idle pool connections
+        // across those per-DB pools otherwise pile up past the MySQL server's max_connections ceiling.
+        _connectionString = $"Server={server};Port={port};User={user};Password={password};AllowUserVariables=true;Pooling=false;{extraProps}";
 
         _integrationSecondaryDb = GenerateUniqueDBName(config["ScriptTokens:SecondaryDB"] ?? "TestSecondary");
         _integrationMainDb = GenerateUniqueDBName(config["ScriptTokens:MainDB"] ?? "TestMain");
@@ -93,6 +95,8 @@ public class FixtureSetup
         config["Target:Password"] = password;
         foreach (var prop in mysqlProps)
             config[$"Target:ConnectionProperties:{prop.Key}"] = prop.Value;
+        // Product-side connections the quench opens per target DB are non-pooled too (same ceiling reason).
+        config["Target:ConnectionProperties:Pooling"] = "false";
         config["ScriptTokens:MainDB"] = _integrationMainDb;
         config["ScriptTokens:SecondaryDB"] = _integrationSecondaryDb;
 

--- a/Schema/Schema.UnitTests/Utility/SchemaGeneratorTests.cs
+++ b/Schema/Schema.UnitTests/Utility/SchemaGeneratorTests.cs
@@ -370,6 +370,148 @@ public class SchemaGeneratorTests
         Assert.That(merged["properties"]?["Extensions"], Is.Not.Null);
     }
 
+    // --- MergeExtensionsDefinition: deep-level preservation (every Extensions-bearing component) ---
+
+    // A user edits a regenerated .schema file, tightening the open Extensions bag into a governance
+    // fragment. On the next regeneration the fragment must survive at EVERY level it was authored,
+    // not just the table root. These build the "existing on-disk" schema by cloning the generated
+    // shape and injecting a distinctively-marked fragment, exactly as a round-trip would produce.
+
+    // SQL Server checks use the base CheckConstraint (no SqlServerCheckConstraint subclass); the base
+    // still carries Extensions via DynamicBase, so it exercises the check-constraint level fine.
+    private static readonly Func<Type, Type> FullSsResolver = SubclassResolver(
+        column: typeof(SqlServerColumn),
+        index: typeof(SqlServerIndex),
+        foreignKey: typeof(SqlServerForeignKey));
+
+    private static JObject Frag(string marker) => new()
+    {
+        ["type"] = "object",
+        ["required"] = new JArray(marker),
+        ["properties"] = new JObject { [marker] = new JObject { ["type"] = "string" } }
+    };
+
+    private static void InjectAtItems(JObject schema, string collection, JObject frag) =>
+        ((JObject)schema["properties"]![collection]!["items"]!["properties"]!)["Extensions"] = frag;
+
+    private static void AssertFrag(JToken ext, string marker)
+    {
+        Assert.That(ext, Is.Not.Null, $"Extensions fragment marked '{marker}' should be preserved");
+        Assert.That(ext!["required"]?[0]?.ToString(), Is.EqualTo(marker));
+        Assert.That(ext["properties"]?[marker], Is.Not.Null);
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesColumnLevelFragment()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        InjectAtItems(existing, "Columns", Frag("Classification"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["Columns"]?["items"]?["properties"]?["Extensions"], "Classification");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesIndexLevelFragment()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        InjectAtItems(existing, "Indexes", Frag("IndexGov"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["Indexes"]?["items"]?["properties"]?["Extensions"], "IndexGov");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesForeignKeyLevelFragment()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        InjectAtItems(existing, "ForeignKeys", Frag("FkGov"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["ForeignKeys"]?["items"]?["properties"]?["Extensions"], "FkGov");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesCheckConstraintLevelFragment()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        InjectAtItems(existing, "CheckConstraints", Frag("CheckGov"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["CheckConstraints"]?["items"]?["properties"]?["Extensions"], "CheckGov");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesStatisticLevelFragment()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        InjectAtItems(existing, "Statistics", Frag("StatGov"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["Statistics"]?["items"]?["properties"]?["Extensions"], "StatGov");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesFullTextIndexFragment_BothOneOfBranches()
+    {
+        // FullTextIndex is SingleOrArray -> a oneOf wrapper; the fragment lives on both the
+        // single-object branch and the array-items branch after a round-trip.
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        var ftOneOf = (JArray)existing["properties"]!["FullTextIndex"]!["oneOf"]!;
+        ((JObject)ftOneOf[0]!["properties"]!)["Extensions"] = Frag("FtObj");
+        ((JObject)ftOneOf[1]!["items"]!["properties"]!)["Extensions"] = Frag("FtArr");
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        var mergedOneOf = (JArray)merged["properties"]!["FullTextIndex"]!["oneOf"]!;
+        AssertFrag(mergedOneOf[0]["properties"]?["Extensions"], "FtObj");
+        AssertFrag(mergedOneOf[1]["items"]?["properties"]?["Extensions"], "FtArr");
+    }
+
+    [Test]
+    public void MergeExtensions_PreservesMultipleLevelsSimultaneously_NoCrossContamination()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone();
+        ((JObject)existing["properties"]!)["Extensions"] = Frag("TableGov");
+        InjectAtItems(existing, "Columns", Frag("ColGov"));
+        InjectAtItems(existing, "Indexes", Frag("IdxGov"));
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        AssertFrag(merged["properties"]?["Extensions"], "TableGov");
+        AssertFrag(merged["properties"]?["Columns"]?["items"]?["properties"]?["Extensions"], "ColGov");
+        AssertFrag(merged["properties"]?["Indexes"]?["items"]?["properties"]?["Extensions"], "IdxGov");
+        // A level with no authored fragment must stay the empty generated bag — nothing leaks across levels.
+        var fkExt = merged["properties"]?["ForeignKeys"]?["items"]?["properties"]?["Extensions"];
+        Assert.That(fkExt, Is.Not.Null);
+        Assert.That(fkExt!["required"], Is.Null, "FK Extensions had no fragment; must stay empty");
+    }
+
+    [Test]
+    public void MergeExtensions_ExistingWithoutDeepFragments_LeavesGeneratedEmpty()
+    {
+        var generated = SchemaGenerator.GenerateSchema(typeof(SqlServerTable), FullSsResolver);
+        var existing = (JObject)generated.DeepClone(); // no fragments injected anywhere
+
+        var merged = SchemaGenerator.MergeExtensionsDefinition(generated, existing);
+
+        var colExt = merged["properties"]?["Columns"]?["items"]?["properties"]?["Extensions"] as JObject;
+        Assert.That(colExt, Is.Not.Null);
+        Assert.That(colExt!.Count, Is.EqualTo(0), "empty Extensions bag stays empty");
+    }
+
     // --- Test helper classes ---
     private class SimpleStringClass { public string Name { get; set; } }
     private class BoolClass { public bool IsActive { get; set; } }

--- a/Schema/Utility/SchemaGenerator.cs
+++ b/Schema/Utility/SchemaGenerator.cs
@@ -33,13 +33,40 @@ public static class SchemaGenerator
     {
         if (existing == null) return generated;
 
-        var existingExtensions = existing["properties"]?["Extensions"];
-        if (existingExtensions == null) return generated;
-
-        if (generated["properties"] is JObject props)
-            props["Extensions"] = existingExtensions.DeepClone();
-
+        // Carry over a hand-authored Extensions fragment wherever the user defined one — table root,
+        // every collection element (columns, indexes, FKs, checks, statistics, ...), single-object
+        // components, and both branches of a SingleOrArray oneOf. Walk both trees in lockstep by
+        // structure so a fragment is only preserved at the location it was authored.
+        MergeExtensionsNode(generated, existing);
         return generated;
+    }
+
+    private static void MergeExtensionsNode(JToken generated, JToken existing)
+    {
+        if (generated is not JObject genObj || existing is not JObject exObj) return;
+
+        if (genObj["properties"] is JObject genProps && exObj["properties"] is JObject exProps)
+        {
+            // Preserve the authored fragment at this level (only where the current model still has the slot).
+            if (genProps["Extensions"] != null && exProps["Extensions"] is { } exExtensions)
+                genProps["Extensions"] = exExtensions.DeepClone();
+
+            // Recurse into every sibling property the two trees share.
+            foreach (var genProp in genProps.Properties())
+            {
+                if (genProp.Name == "Extensions") continue;
+                if (exProps[genProp.Name] is { } exChild)
+                    MergeExtensionsNode(genProp.Value, exChild);
+            }
+        }
+
+        // Descend through array element schemas and each SingleOrArray oneOf branch.
+        if (genObj["items"] is { } genItems && exObj["items"] is { } exItems)
+            MergeExtensionsNode(genItems, exItems);
+
+        if (genObj["oneOf"] is JArray genOneOf && exObj["oneOf"] is JArray exOneOf)
+            for (var i = 0; i < genOneOf.Count && i < exOneOf.Count; i++)
+                MergeExtensionsNode(genOneOf[i], exOneOf[i]);
     }
 
     private static JObject BuildObjectSchema(Type type, Func<Type, Type> elementTypeResolver)

--- a/TestProducts/MySQL/AfterProductScriptError/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/AfterProductScriptError/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/AfterProductScriptError/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/AfterProductScriptError/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/AfterProductScriptError/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/AfterProductScriptError/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/MySQL/BadVersionStamp/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/BadVersionStamp/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/BadVersionStamp/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/BadVersionStamp/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/BadVersionStamp/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/BadVersionStamp/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/BeforeTemplateScriptError/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/MySQL/InvalidServer/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/InvalidServer/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/InvalidServer/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/InvalidServer/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/InvalidServer/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/InvalidServer/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/TemplateObjectsScriptError/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/MySQL/ValidProduct/.json-schemas/products.mysql.schema
+++ b/TestProducts/MySQL/ValidProduct/.json-schemas/products.mysql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/MySQL/ValidProduct/.json-schemas/tables.mysql.schema
+++ b/TestProducts/MySQL/ValidProduct/.json-schemas/tables.mysql.schema
@@ -129,11 +129,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -221,6 +221,30 @@
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
     },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
     "OldName": {
       "type": "string"
     },
@@ -229,7 +253,7 @@
     },
     "RowFormat": {
       "type": "string",
-      "pattern": "DYNAMIC|COMPACT|COMPRESSED|REDUNDANT"
+      "pattern": "Dynamic|Compact|Compressed|Redundant|Fixed"
     },
     "CharacterSet": {
       "type": "string"
@@ -241,9 +265,7 @@
       "type": "string"
     },
     "AutoIncrementValue": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
+      "type": "integer",
       "minimum": 1.0
     },
     "FullTextIndexes": {

--- a/TestProducts/MySQL/ValidProduct/.json-schemas/templates.mysql.schema
+++ b/TestProducts/MySQL/ValidProduct/.json-schemas/templates.mysql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/AfterProductScriptError/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/BadVersionStamp/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/BeforeTemplateScriptError/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/InvalidServer/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/InvalidServer/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/InvalidServer/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/InvalidServer/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/InvalidServer/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/InvalidServer/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/TemplateObjectsScriptError/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/PostgreSQL/ValidProduct/.json-schemas/products.postgresql.schema
+++ b/TestProducts/PostgreSQL/ValidProduct/.json-schemas/products.postgresql.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/PostgreSQL/ValidProduct/.json-schemas/tables.postgresql.schema
+++ b/TestProducts/PostgreSQL/ValidProduct/.json-schemas/tables.postgresql.schema
@@ -147,11 +147,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -254,6 +254,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/PostgreSQL/ValidProduct/.json-schemas/templates.postgresql.schema
+++ b/TestProducts/PostgreSQL/ValidProduct/.json-schemas/templates.postgresql.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -68,11 +69,34 @@
     },
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/AfterProductScriptError/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/BadVersionStamp/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/BadVersionStamp/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/BadVersionStamp/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/BadVersionStamp/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/BadVersionStamp/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/BadVersionStamp/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/BeforeTemplateScriptError/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/InvalidServer/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/InvalidServer/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/InvalidServer/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/InvalidServer/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/InvalidServer/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/InvalidServer/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/TemplateObjectsScriptError/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }

--- a/TestProducts/SqlServer/ValidProduct/.json-schemas/products.sqlserver.schema
+++ b/TestProducts/SqlServer/ValidProduct/.json-schemas/products.sqlserver.schema
@@ -28,7 +28,8 @@
             "type": "integer"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -73,6 +74,27 @@
     "CheckConstraintStyle": {
       "type": "string",
       "pattern": "ColumnLevel|TableLevel"
+    },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/TestProducts/SqlServer/ValidProduct/.json-schemas/tables.sqlserver.schema
+++ b/TestProducts/SqlServer/ValidProduct/.json-schemas/tables.sqlserver.schema
@@ -148,11 +148,11 @@
           },
           "DeleteAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "UpdateAction": {
             "type": "string",
-            "pattern": "NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT"
+            "pattern": "^(NO ACTION|RESTRICT|CASCADE|SET NULL|SET DEFAULT)?$"
           },
           "ShouldApplyExpression": {
             "type": "string"
@@ -239,6 +239,30 @@
       "type": "string",
       "maxLength": 128,
       "description": "Optional label for a conditional variant — names the intent behind its ShouldApplyExpression and appears in deployment logging when the variant is applied."
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropColumnsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropForeignKeysRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropCheckConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropExcludeConstraintsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting. PostgreSQL only."
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropStatisticsRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean",
+      "description": "When set, overrides the template- and product-level DropIndexesRemovedFromProduct flag for this table only. Null inherits from the template (or product) setting."
     },
     "OldName": {
       "type": "string"

--- a/TestProducts/SqlServer/ValidProduct/.json-schemas/templates.sqlserver.schema
+++ b/TestProducts/SqlServer/ValidProduct/.json-schemas/templates.sqlserver.schema
@@ -22,7 +22,8 @@
             "type": "string"
           },
           "QuenchSlot": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "Before|Objects|BetweenTablesAndKeys|AfterTablesScripts|AfterTablesObjects|TableData|After|None"
           },
           "ObjectType": {
             "type": "string",
@@ -69,14 +70,36 @@
     "ContinueOnDatabaseFailure": {
       "type": "boolean"
     },
+    "DropTablesRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropUnknownIndexes": {
+      "type": "boolean"
+    },
+    "DropColumnsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropForeignKeysRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropCheckConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropExcludeConstraintsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropStatisticsRemovedFromProduct": {
+      "type": "boolean"
+    },
+    "DropIndexesRemovedFromProduct": {
+      "type": "boolean"
+    },
     "ServerToQuench": {
       "type": "integer"
     }
   },
   "additionalProperties": false,
   "required": [
-    "Name",
-    "DatabaseIdentificationScript",
-    "ServerToQuench"
+    "Name"
   ]
 }


### PR DESCRIPTION
## What

Three related RC2 changes on one branch:

1. **Fix #320 — preserve `Extensions` schema-fragment governance at every component level.** `SchemaGenerator.MergeExtensionsDefinition` only carried a hand-authored `Extensions` JSON-Schema fragment at the table root; a fragment authored deeper — column, index, foreign key, check constraint, statistic, XML index, full-text index, exclude constraint, or the indexes of an indexed/materialized view — was silently discarded and rebuilt as an empty bag on every `--WriteSchemasOnly` run and every SchemaTongs extraction. That contradicts the shipped reference docs, which instruct authoring column-level governance under `properties.Columns.items.properties.Extensions` and promise it survives the round-trip. The top-level-only copy is replaced with a location-exact recursive lockstep walk of the generated and existing schema trees — descending child properties, array `items`, and both `oneOf` branches of a `SingleOrArray` (FullTextIndex) — so a fragment is preserved wherever it was authored, at every level and across the table / materialized-view / indexed-view schema variants, with no cross-level leakage. Generalizes to any future `Extensions`-bearing component with no per-level code.

2. **RC2 dependency currency bump.** Engine drivers `Microsoft.Data.SqlClient` 7.0.1→7.0.2, `MySqlConnector` 2.5.0→2.6.1, `Npgsql` 10.0.2→10.0.3; `log4net` 3.3.1→3.3.2; the `Microsoft.Extensions.Configuration.*` family 10.0.7→10.0.9; test infra `Microsoft.NET.Test.Sdk` 18.5.1→18.7.0, `NUnit` 4.6.0→4.6.1, `NUnit.Analyzers` 4.13.0→4.14.0.

3. **Regenerate committed editor `.json-schemas` (360 files).** The committed schemas across `Demos/` and `TestProducts/` had drifted from the shipped v2.2.0 domain model — missing the drop-control cascade properties, the QuenchSlot integer→string-enum, the FK `UpdateAction`/`DeleteAction` empty-value pattern, and the MySQL RowFormat casing. Regenerated via `--WriteSchemasOnly`; artifact refresh only, no code or CLI-behavior change.

4. **MySQL integration test stabilization (non-pooled connections).** The MySQL integration fixtures create a unique database per test and open a distinct connection pool per database (both test-verification and product-side connections). Retained idle pool connections accumulate past the server's `max_connections` ceiling over a full run, so fixture SetUp intermittently failed with "Too many connections" (error 1040) under the full concurrent suite. Pre-existing and driver-independent — reproduces identically on MySqlConnector 2.5.0 and 2.6.1, so unrelated to the dep bump. Fix: disable pooling for the MySQL integration connections so peak usage tracks concurrent-in-use only.

## Testing

- **Unit:** 1567 passing (Schema.UnitTests), including 8 new `Extensions`-preservation tests (one per component level + no-cross-contamination + empty-bag guard).
- **Full multi-engine integration suite** (SQL Server + PostgreSQL + MySQL): 1080 passing across the four integration projects — Schema 135, SchemaQuench 755, SchemaTongs 73, DataTongs 117 — all green.
- Restore + build clean, 0 warnings.

Closes #320
